### PR TITLE
Changed nltk_download setup.py call in Makefile to utilize PYTHON variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ download: nltk_download
 	$(TARBALL_EXTRACT) $(DATA)/$(RAW_DATA_PACKAGE)
 
 nltk_download:
-	python setup.py nltk_download
+	$(PYTHON) setup.py nltk_download
 
 download_db: nltk_download
 	@mkdir -p $(DATA)


### PR DESCRIPTION
Changed nltk_download setup.py call in Makefile to utilize PYTHON variable defined in the beginning of the file rather than use straight "python".
