### PR TITLE
modify zh_frames.json to erase the false meanning of relation mapping

### DIFF
--- a/conceptnet5/support_data/zh_frames.json
+++ b/conceptnet5/support_data/zh_frames.json
@@ -157,19 +157,19 @@
   }, 
   "3392": {
     "text": "{1} 不想要 {2}。", 
-    "relation": "/r/Desires"
+    "relation": "/r/NotDesires"
   }, 
   "3393": {
     "text": "{1} 懼怕 {2}。", 
-    "relation": "/r/Desires"
+    "relation": "/r/NotDesires"
   }, 
   "3394": {
     "text": "{1} 不想得到 {2}。", 
-    "relation": "/r/Desires"
+    "relation": "/r/NotDesires"
   }, 
   "3395": {
     "text": "{1} 痛恨 {2}。", 
-    "relation": "/r/Desires"
+    "relation": "/r/NotDesires"
   }, 
   "3396": {
     "text": "{1} 和 {2} 通常會一起出現。", 


### PR DESCRIPTION
When used Chinese data source, zh_frames.json is used to mapping Chinese sentence meaning to English relations. However there are mistakes in some mapping as I have point out.  The mistakes cause related commonsense knowledge  became nonsense in Chinese! for example:
('[[助教]] 痛恨 [[爆炸]]。', '助教', '爆炸', 'Desires')