### PR TITLE
fix snakefile shell order bug for building target of load_db

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -349,7 +349,7 @@ rule load_db:
     output:
         DATA + "/psql/done"
     shell:
-        "cn5-db load_data %(data)s/psql && touch {output}" % {'data': DATA}
+        "touch {output} && cn5-db load_data %(data)s/psql" % {'data': DATA}
 
 
 # Collecting statistics


### PR DESCRIPTION
As the load_data() function shows that 'done' file had to be touch before cn5-db run. 
However ,  two shell joined together with "&&" mean  the left one will be execute first.
So load_data assert driggered and exit ,  build process interrupted.