### PR TITLE
Clean up and test vector space I/O

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -656,7 +656,7 @@ rule compare_embeddings:
     run:
         input_embeddings = input[:-2]
         input_embeddings_str = ' '.join(input_embeddings)
-        shell("cn5-vectors compare_embeddings %s {output}" % input_embeddings)
+        shell("cn5-vectors compare_embeddings %s {output}" % input_embeddings_str)
 
 rule comparison_graph:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -600,12 +600,19 @@ rule miniaturize:
 rule export_text:
     input:
         DATA + "/vectors/numberbatch.h5",
-        DATA + "/stats/terms.txt",
-        DATA + "/psql/done"
     output:
-        DATA + "/vectors/plain/conceptnet-numberbatch_uris_main.txt.gz"
+        DATA + "/vectors/plain/numberbatch.txt.gz"
     shell:
-        "cn5-vectors export_text %(data)s/vectors/numberbatch.h5 %(data)s/stats/terms.txt %(data)s/vectors/plain/conceptnet-numberbatch" % {'data': DATA}
+        "cn5-vectors export_text {input} {output}"
+
+
+rule export_english_text:
+    input:
+        DATA + "/vectors/numberbatch.h5",
+    output:
+        DATA + "/vectors/plain/numberbatch-en.txt.gz"
+    shell:
+        "cn5-vectors export_text -l en {input} {output}"
 
 
 rule sha256sums:
@@ -629,21 +636,25 @@ rule compare_embeddings:
     input:
         DATA + "/raw/vectors/GoogleNews-vectors-negative300.bin.gz",
         DATA + "/raw/vectors/glove12.840B.300d.txt.gz",
-        DATA + "/raw/vectors/lexvec.no-header.vectors.gz",
-        DATA + "/precomputed/vectors/conceptnet-55-ppmi.h5",
-        DATA + "/precomputed/vectors/numberbatch.h5",
+        DATA + "/vectors/glove12-840B.h5",
+        DATA + "/raw/vectors/fasttext-wiki-en.vec.gz",
+        DATA + "/vectors/numberbatch-biased.h5",
+        DATA + "/vectors/numberbatch.h5",
         DATA + "/raw/analogy/SAT-package-V3.txt",
         DATA + "/psql/done"
     output:
         DATA + "/stats/evaluation.h5"
-    shell:
-        "cn5-vectors compare_embeddings %(data)s/raw/vectors/GoogleNews-vectors-negative300.bin.gz %(data)s/raw/vectors/glove12.840B.300d.txt.gz %(data)s/raw/vectors/lexvec.no-header.vectors.gz %(data)s/precomputed/vectors/conceptnet-55-ppmi.h5 %(data)s/precomputed/vectors/numberbatch.h5 {output}" % {'data': DATA}
+    run:
+        input_embeddings = input[:-2]
+        input_embeddings_str = ' '.join(input_embeddings)
+        shell("cn5-vectors compare_embeddings %s {output}" % input_embeddings)
 
 rule comparison_graph:
     input:
         DATA + "/stats/evaluation.h5"
     output:
-        DATA + "/stats/eval-graph.pdf"
+        DATA + "/stats/eval-graph.png",
+        DATA + "/stats/bias-graph.png"
     shell:
         "cn5-vectors comparison_graph {input} {output}"
 

--- a/conceptnet5/vectors/__init__.py
+++ b/conceptnet5/vectors/__init__.py
@@ -45,7 +45,7 @@ def get_vector(frame, label, language=None):
     and normalize it to ConceptNet form. Either way, it can also take in
     a label that is already in ConceptNet form.
     """
-    if frame.index[0].startswith('/'): # This frame has URIs in its index
+    if frame.index[1].startswith('/c/'):  # This frame has URIs in its index
         if not label.startswith('/'):
             label = standardized_uri(language, label)
         try:

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -6,7 +6,9 @@ from .formats import (
 from .retrofit import sharded_retrofit, join_shards
 from .merge import merge_intersect
 from .evaluation import wordsim, analogy, bias
-from .evaluation.compare import compare_embeddings, graph_comparison
+from .evaluation.compare import (
+    compare_embeddings, graph_comparison, graph_bias_comparison
+)
 from .miniaturize import miniaturize
 from .debias import de_bias_frame
 from .query import VectorSpaceWrapper
@@ -186,12 +188,14 @@ def run_compare_embeddings(input_filenames, output_filename):
 
 @cli.command(name='comparison_graph')
 @click.argument('table_filename', type=click.Path(readable=True, dir_okay=False))
-@click.argument('out_filename', type=click.Path(writable=True, dir_okay=False))
-def run_comparison_graph(table_filename, out_filename):
+@click.argument('eval_graph_filename', type=click.Path(writable=True, dir_okay=False))
+@click.argument('bias_graph_filename', type=click.Path(writable=True, dir_okay=False))
+def run_comparison_graph(table_filename, eval_graph_filename, bias_graph_filename):
     """
     Convert a table of evaluation results into a PNG or PDF graph.
     """
-    graph_comparison(table_filename, out_filename)
+    graph_comparison(table_filename, eval_graph_filename)
+    graph_bias_comparison(table_filename, bias_graph_filename)
 
 
 @cli.command(name='export_hyperwords')

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -1,7 +1,7 @@
 import click
 from .formats import (
     convert_glove, convert_word2vec, convert_fasttext, convert_polyglot,
-    load_hdf, save_hdf, export_conceptnet_to_hyperwords, export_plain_text
+    load_hdf, save_hdf, export_conceptnet_to_hyperwords, export_text
 )
 from .retrofit import sharded_retrofit, join_shards
 from .merge import merge_intersect
@@ -206,11 +206,11 @@ def run_export_hyperwords(input_filename, output_matrix, output_vocab, nrows=200
 
 @cli.command(name='export_text')
 @click.argument('input_filename', type=click.Path(readable=True, dir_okay=False))
-@click.argument('uri_filename', type=click.Path(readable=True, dir_okay=False))
-@click.argument('output_dir', type=click.Path(writable=True, dir_okay=True, file_okay=False))
-def run_export(input_filename, uri_filename, output_dir):
+@click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
+@click.option('--language', '-l', default=None)
+def run_export(input_filename, output_filename, language):
     frame = load_hdf(input_filename)
-    export_plain_text(frame, uri_filename, output_dir)
+    export_text(frame, output_filename, language)
 
 
 @cli.command(name='miniaturize')

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -1,7 +1,7 @@
 import click
 from .formats import (
     convert_glove, convert_word2vec, convert_fasttext, convert_polyglot,
-    load_hdf, save_hdf, export_conceptnet_to_hyperwords, export_text
+    load_hdf, save_hdf, export_text
 )
 from .retrofit import sharded_retrofit, join_shards
 from .merge import merge_intersect
@@ -196,16 +196,6 @@ def run_comparison_graph(table_filename, eval_graph_filename, bias_graph_filenam
     """
     graph_comparison(table_filename, eval_graph_filename)
     graph_bias_comparison(table_filename, bias_graph_filename)
-
-
-@cli.command(name='export_hyperwords')
-@click.argument('input_filename', type=click.Path(readable=True, dir_okay=False))
-@click.argument('output_matrix', type=click.Path(writable=True, dir_okay=False))
-@click.argument('output_vocab', type=click.Path(writable=True, dir_okay=False))
-@click.option('--nrows', '-n', default=200000)
-def run_export_hyperwords(input_filename, output_matrix, output_vocab, nrows=200000):
-    frame = load_hdf(input_filename)
-    export_conceptnet_to_hyperwords(frame, output_matrix, output_vocab, nrows=nrows)
 
 
 @cli.command(name='export_text')

--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -1,8 +1,6 @@
-from conceptnet5.util import get_support_data_filename
-from conceptnet5.vectors import standardized_uri, get_vector, cosine_similarity, normalize_vec
+from conceptnet5.vectors import standardized_uri, normalize_vec
 from conceptnet5.vectors.transforms import l2_normalize_rows
 import numpy as np
-import pandas as pd
 from sklearn import svm
 
 

--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -350,7 +350,7 @@ GENDER_NEUTRAL_WORDS = [
     'workout', 'pilates',
     'home depot', 'jcpenney',
     'carpentry', 'sewing',
-    'accountant', 'paralegal'
+    'accountant', 'paralegal',
     'addiction', 'eating disorder',
     'professor emeritus', 'associate professor',
     'programmer', 'homemaker'
@@ -392,9 +392,10 @@ def reject_subspace(frame, vecs):
     """
     current_array = frame.copy()
     for vec in vecs:
-        vec = normalize_vec(vec)
-        projection = current_array.dot(vec)
-        current_array -= np.outer(projection, vec)
+        if not np.isnan(vec).any():
+            vec = normalize_vec(vec)
+            projection = current_array.dot(vec)
+            current_array -= np.outer(projection, vec)
 
     return l2_normalize_rows(current_array, offset=1e-9)
 

--- a/conceptnet5/vectors/evaluation/bias.py
+++ b/conceptnet5/vectors/evaluation/bias.py
@@ -2,15 +2,14 @@ import numpy as np
 import pandas as pd
 import scipy
 
-from conceptnet5.vectors import standardized_uri, normalize_vec
+from conceptnet5.vectors import standardized_uri, normalize_vec, get_vector
 from conceptnet5.vectors.transforms import (
     l2_normalize_rows, subtract_mean_vector
 )
 from conceptnet5.vectors.debias import (
     FEMALE_WORDS, MALE_WORDS, PEOPLE_BY_BELIEF, PEOPLE_BY_ETHNICITY,
-    CULTURE_PREJUDICES, get_category_axis, get_vocabulary_vectors
+    get_category_axis, get_vocabulary_vectors
 )
-from conceptnet5.vectors.query import VectorSpaceWrapper
 
 # A list of gender-stereotyped pairs, from Bolukbasi et al.:
 # https://arxiv.org/pdf/1607.06520.pdf
@@ -196,15 +195,16 @@ def measure_bias(frame):
     - Coarse-grained ethnicity
     - Religious beliefs
     """
-    vsw = VectorSpaceWrapper(frame=frame)
-    vsw.load()
+    # Assume English for DataFrames that don't have language tags.
+    if '/c/' not in frame.index[0]:
+        frame.index = ['/c/en/%s' % label for label in frame.index]
 
     gender_binary_axis = normalize_vec(get_category_axis(frame, FEMALE_WORDS) - get_category_axis(frame, MALE_WORDS))
     gender_bias_numbers = []
     for female_biased_word, male_biased_word in GENDER_BIAS_PAIRS:
         female_biased_uri = standardized_uri('en', female_biased_word)
         male_biased_uri = standardized_uri('en', male_biased_word)
-        diff = normalize_vec(vsw.get_vector(female_biased_uri) - vsw.get_vector(male_biased_uri)).dot(gender_binary_axis)
+        diff = normalize_vec(get_vector(frame, female_biased_uri) - get_vector(frame, male_biased_uri)).dot(gender_binary_axis)
         gender_bias_numbers.append(diff)
 
     mean = np.mean(gender_bias_numbers)

--- a/conceptnet5/vectors/evaluation/bias.py
+++ b/conceptnet5/vectors/evaluation/bias.py
@@ -195,10 +195,6 @@ def measure_bias(frame):
     - Coarse-grained ethnicity
     - Religious beliefs
     """
-    # Assume English for DataFrames that don't have language tags.
-    if '/c/' not in frame.index[0]:
-        frame.index = ['/c/en/%s' % label for label in frame.index]
-
     gender_binary_axis = normalize_vec(get_category_axis(frame, FEMALE_WORDS) - get_category_axis(frame, MALE_WORDS))
     gender_bias_numbers = []
     for female_biased_word, male_biased_word in GENDER_BIAS_PAIRS:

--- a/conceptnet5/vectors/evaluation/compare.py
+++ b/conceptnet5/vectors/evaluation/compare.py
@@ -1,5 +1,5 @@
-from conceptnet5.vectors.evaluation import analogy, story, wordsim
-from conceptnet5.vectors.formats import load_hdf, save_hdf, load_glove, load_word2vec_bin
+from conceptnet5.vectors.evaluation import analogy, story, wordsim, bias
+from conceptnet5.vectors.formats import load_hdf, save_hdf, load_glove, load_fasttext, load_word2vec_bin
 import numpy as np
 import pandas as pd
 
@@ -11,7 +11,9 @@ ANALOGY_FILENAME = 'data/raw/analogy/SAT-package-V3.txt'
 def load_any_embeddings(filename):
     if filename.endswith('.bin.gz'):
         return load_word2vec_bin(filename, 1000000)
-    elif filename.endswith('.gz'):
+    elif filename.endswith('.vectors.gz') or filename.endswith('.vec.gz'):
+        return load_fasttext(filename, 1000000)
+    elif filename.endswith('.txt.gz'):
         return load_glove(filename, 1000000)
     elif filename.endswith('.h5'):
         return load_hdf(filename)
@@ -20,18 +22,18 @@ def load_any_embeddings(filename):
 
 
 def compare_embeddings(filenames, subset='dev', tune_analogies=True):
-    embeddings = [
-        load_any_embeddings(filename) for filename in filenames
-    ]
     results = []
-    for frame in embeddings:
-        wordsim_results = wordsim.evaluate(frame, subset=subset)
-        analogy_results = analogy.evaluate(frame, ANALOGY_FILENAME, tune_analogies=True)
+    for filename in filenames:
+        print(filename)
+        frame = load_any_embeddings(filename)
+        wordsim_results = wordsim.evaluate(frame, subset=subset, semeval_scope='per-language')
+        analogy_results = analogy.evaluate(frame, ANALOGY_FILENAME, tune_analogies=tune_analogies)
         story_results = story.evaluate(frame, subset=subset).to_frame('story-cloze').T
+        bias_results = bias.measure_bias(frame)
 
         results.append(
             pd.concat(
-                [wordsim_results, analogy_results, story_results], axis=0
+                [wordsim_results, analogy_results, story_results, bias_results], axis=0
             )
         )
     result = pd.concat(results, keys=filenames)
@@ -42,30 +44,32 @@ def compare_embeddings(filenames, subset='dev', tune_analogies=True):
 def graph_comparison(table_filename, out_filename):
     import matplotlib.pyplot as plt
     result = load_hdf(table_filename)
-    plt.style.use('bmh')
+    # plt.style.use('bmh')
     plt.rcParams['xtick.labelsize'] = 'x-large'
     plt.rcParams['ytick.labelsize'] = 'x-large'
 
-    patterns = [ "/", "\\" , "//" , "\\\\" , " " ]
-    width = 0.15
-    evals = ['men3000', 'rw', 'mturk', 'ws353', 'story-cloze', 'sat-analogies']
-    eval_labels = ['MEN-3000', 'Rare Words', 'MTurk-771', 'WS353', 'Story Cloze', 'SAT analogies']
-    colors = [props['color'] for props in plt.rcParams['axes.prop_cycle']]
+    evals = ['men3000', 'rw', 'mturk', 'ws353', 'semeval-2a-en']
+    eval_labels = ['MEN-3000', 'Rare Words', 'MTurk-771', 'WordSim-353', 'SemEval 2017-2a']
+    prop_cycle = list(plt.rcParams['axes.prop_cycle'])
+    colors = [props['color'] for props in prop_cycle]
 
     systems = [
         ('word2vec Google News', 'data/raw/vectors/GoogleNews-vectors-negative300.bin.gz'),
         ('GloVe 1.2 840B', 'data/raw/vectors/glove12.840B.300d.txt.gz'),
-        ('LexVec: enWP + NewsCrawl', 'data/raw/vectors/lexvec.no-header.vectors.gz'),
-        ('ConceptNet-PPMI', 'data/precomputed/vectors/conceptnet-55-ppmi.h5'),
-        ('ConceptNet Numberbatch', 'data/precomputed/vectors/numberbatch.h5')
+        ('GloVe renormalized', 'data/vectors/glove12-840B.h5'),
+        ('fastText enWP (without OOV)', 'data/raw/vectors/fasttext-wiki-en.vec.gz'),
+        # ('ConceptNet Numberbatch biased', 'data/vectors/numberbatch-biased.h5'),
+        ('ConceptNet Numberbatch 17.04', 'data/vectors/numberbatch.h5')
     ]
+    width = 0.84 / len(systems)
     ind = np.arange(len(evals))
 
     fig, ax = plt.subplots(figsize=(16, 8))
     for i, (sysname, syspath) in enumerate(systems):
         eval_table = result.xs(syspath, level=0).loc[evals]
-        errs = [eval_table['high'] - eval_table['acc'], eval_table['acc'] - eval_table['low']]
-        ax.bar(ind + i * width, eval_table['acc'], width, hatch=patterns[i], color=colors[i], yerr=errs, ecolor='k')
+        value = eval_table['acc']
+        errs = [eval_table['high'] - value, value - eval_table['low']]
+        ax.bar(ind + i * width, value, width * 0.9, color=colors[i], yerr=errs, ecolor='k')
 
     ax.set_ylim(0.0, 1.0)
     ax.set_yticks(np.arange(0.0, 1.1, 0.1))
@@ -73,5 +77,49 @@ def graph_comparison(table_filename, out_filename):
     ax.set_xticks(ind + width * len(systems) / 2)
     ax.set_xticklabels(eval_labels)
     ax.xaxis.grid(False)
-    plt.ylabel('Evaluation score', fontsize='x-large')
+    ax.yaxis.grid(True)
+    ax.set_axisbelow(True)
+    plt.ylabel('Evaluation score (Spearman \N{GREEK SMALL LETTER RHO})', fontsize='x-large')
+    plt.savefig(out_filename, bbox_inches="tight", dpi=300)
+
+
+def graph_bias_comparison(table_filename, out_filename):
+    import matplotlib.pyplot as plt
+    result = load_hdf(table_filename)
+    # plt.style.use('bmh')
+    plt.rcParams['xtick.labelsize'] = 'x-large'
+    plt.rcParams['ytick.labelsize'] = 'x-large'
+
+    evals = ['gender', 'beliefs', 'ethnicity-coarse', 'ethnicity-fine', 'ethnicity-names']
+    eval_labels = ['Gender bias', 'Religious bias', 'Ethnic bias (coarse)', 'Ethnic bias (fine)', 'Bias from names']
+    prop_cycle = list(plt.rcParams['axes.prop_cycle'])
+    colors = [props['color'] for props in prop_cycle]
+
+    systems = [
+        ('word2vec Google News', 'data/raw/vectors/GoogleNews-vectors-negative300.bin.gz'),
+        ('GloVe 1.2 840B', 'data/raw/vectors/glove12.840B.300d.txt.gz'),
+        ('GloVe renormalized', 'data/vectors/glove12-840B.h5'),
+        ('fastText enWP (without OOV)', 'data/raw/vectors/fasttext-wiki-en.vec.gz'),
+        # ('ConceptNet Numberbatch biased', 'data/vectors/numberbatch-biased.h5'),
+        ('ConceptNet Numberbatch 17.04', 'data/vectors/numberbatch.h5')
+    ]
+    width = 0.84 / len(systems)
+    ind = np.arange(len(evals))
+
+    fig, ax = plt.subplots(figsize=(16, 8))
+    for i, (sysname, syspath) in enumerate(systems):
+        eval_table = result.xs(syspath, level=0).loc[evals]
+        value = eval_table['bias']
+        errs = [eval_table['high'] - value, value - eval_table['low']]
+        ax.bar(ind + i * width, value, width * 0.9, color=colors[i], yerr=errs, ecolor='k')
+
+    ax.set_ylim(0.0, 0.4)
+    ax.set_yticks(np.arange(0.0, 0.5, 0.1))
+    ax.legend([name for (name, path) in systems], bbox_to_anchor=(1.02, 1), loc=2, borderaxespad=0.)
+    ax.set_xticks(ind + width * len(systems) / 2)
+    ax.set_xticklabels(eval_labels)
+    ax.xaxis.grid(False)
+    ax.yaxis.grid(True)
+    ax.set_axisbelow(True)
+    plt.ylabel('Correlation with stereotypes', fontsize='x-large')
     plt.savefig(out_filename, bbox_inches="tight", dpi=300)

--- a/conceptnet5/vectors/formats.py
+++ b/conceptnet5/vectors/formats.py
@@ -1,89 +1,54 @@
 import pandas as pd
 import numpy as np
-from scipy import sparse
 import gzip
 import struct
-import wordfreq
 import pickle
 from .transforms import l1_normalize_columns, l2_normalize_rows, standardize_row_labels
-from ..vectors import standardized_uri, get_vector
-from conceptnet5.languages import COMMON_LANGUAGES
-from conceptnet5.nodes import get_uri_language
 
 
 def load_hdf(filename):
+    """
+    Load a semantic vector space from an HDF5 file.
+
+    HDF5 is a complex format that can contain many instances of different kinds
+    of data. The convention we use is that the file contains one labeled
+    matrix, named "mat".
+    """
     return pd.read_hdf(filename, 'mat', encoding='utf-8')
 
 
 def save_hdf(table, filename):
+    """
+    Save a semantic vector space into an HDF5 file, following the convention
+    of storing it as a labeled matrix named 'mat'.
+    """
     return table.to_hdf(filename, 'mat', encoding='utf-8')
 
 
-def save_npy_and_labels(table, matrix_filename, vocab_filename):
-    # TODO: find out if we're using this
+def save_labels_and_npy(table, vocab_filename, matrix_filename):
+    """
+    Save a semantic vector space in two files: a NumPy .npy file of the matrix,
+    and a text file with one label per line. We use this for exporting the
+    Luminoso background space.
+    """
     np.save(matrix_filename, table.values)
     save_index_as_labels(table.index, vocab_filename)
 
 
-def export_conceptnet_to_hyperwords(table, matrix_filename, vocab_filename, nrows):
-    vecs = []
-    labels = []
-    english_labels = [
-        standardized_uri('en', item)
-        for item in wordfreq.top_n_list('en', nrows * 2, 'large')
-    ]
-    count = 0
-    for label in english_labels:
-        if label in table.index:
-            labels.append(label.split('/')[-1])
-            vecs.append(get_vector(table, label))
-            count += 1
-            if count >= nrows:
-                break
-    np.save(matrix_filename, np.vstack(vecs))
-    save_index_as_labels(labels, vocab_filename)
-
-
 def vec_to_text_line(label, vec):
+    """
+    Output a labeled vector as a line in a fastText-style text format.
+    """
     cells = [label] + ['%4.4f' % val for val in vec]
     return ' '.join(cells)
 
 
-def export_multiple_text(table, uri_file, file_base):
-    from ..vectors.query import VectorSpaceWrapper
-
-    uri_main_file = gzip.open(file_base + '_uris_main.txt.gz', 'wt')
-    english_main_file = gzip.open(file_base + '_en_main.txt.gz', 'wt')
-    english_extra_file = gzip.open(file_base + '_en_extra.txt.gz', 'wt')
-    wrap = VectorSpaceWrapper(frame=table)
-
-    for line in open(uri_file, encoding='utf-8'):
-        uri = line.strip()
-        if uri.count('/') == 3 and get_uri_language(uri) in COMMON_LANGUAGES:
-            if uri in table.index:
-                vec = table.loc[uri].values
-                print(vec_to_text_line(uri, vec), file=uri_main_file)
-            else:
-                if not uri.startswith('/c/en') or '_' in uri:
-                    continue
-                vec = wrap.get_vector(uri)
-
-            if vec.dot(vec) == 0:
-                continue
-
-            if uri.startswith('/c/en/'):
-                label = uri[6:]
-                if uri in table.index:
-                    print(vec_to_text_line(label, vec), file=english_main_file)
-                else:
-                    print(vec_to_text_line(label, vec), file=english_extra_file)
-
-    uri_main_file.close()
-    english_main_file.close()
-    english_extra_file.close()
-
-
 def export_text(frame, filename, filter_language=None):
+    """
+    Save a semantic vector space as a fastText-style text file.
+
+    If `filter_language` is set, it will output only vectors in that language.
+    """
     vectors = frame.values
     index = frame.index
     if filter_language is not None:
@@ -144,25 +109,19 @@ def convert_word2vec(word2vec_filename, output_filename, nrows, language='en'):
 
 
 def convert_polyglot(polyglot_filename, output_filename, language):
+    """
+    Convert Polyglot data from its pickled format to an HDF5 dataframe.
+    """
     pg_raw = load_polyglot(polyglot_filename)
     pg_std = standardize_row_labels(pg_raw, language, forms=False)
     del pg_raw
     save_hdf(pg_std, output_filename)
 
 
-def load_glove(filename, nrows=500000):
-    # TODO: just make this a variant of load_fasttext, or make load_fasttext
-    # a variant of this
-    with gzip.open(filename, 'rt') as infile:
-        return pd.read_table(
-            infile, sep=' ', index_col=0, quoting=3,
-            keep_default_na=False, na_values=[],
-            names=['term'] + list(range(300)),
-            nrows=nrows
-        )
-
-
 def load_fasttext(filename, max_rows=1000000):
+    """
+    Load a DataFrame from the fastText text format.
+    """
     arr = None
     labels = []
     with gzip.open(filename, 'rt') as infile:
@@ -199,6 +158,11 @@ def _read_vec(file, ndims):
 
 
 def load_word2vec_bin(filename, nrows):
+    """
+    Load a DataFrame from word2vec's binary format. (word2vec's text format
+    should be the same as fastText's, but it's less efficient to load the
+    word2vec data that way.)
+    """
     label_list = []
     vec_list = []
     with gzip.open(filename, 'rb') as infile:
@@ -220,34 +184,37 @@ def load_word2vec_bin(filename, nrows):
 
 
 def load_polyglot(filename):
+    """
+    Load a pickled matrix from the Polyglot format.
+    """
     labels, mat = pickle.load(open(filename, 'rb'), encoding='bytes')
     label_list = list(labels)
     return pd.DataFrame(mat, index=label_list, dtype='f')
 
 
-def save_csr(matrix, filename):
-    np.savez(filename, data=matrix.data, indices=matrix.indices,
-             indptr=matrix.indptr, shape=matrix.shape)
-
-
 def load_labels_and_npy(label_file, npy_file):
+    """
+    Load a semantic vector space from two files: a NumPy .npy file of the matrix,
+    and a text file with one label per line.
+    """
     labels = [line.rstrip('\n') for line in open(label_file, encoding='utf-8')]
     npy = np.load(npy_file)
     return pd.DataFrame(npy, index=labels, dtype='f')
 
 
 def load_labels_as_index(label_filename):
+    """
+    Load a set of labels (with no attached vectors) from a text file, and
+    represent them in a pandas Index.
+    """
     labels = [line.rstrip('\n') for line in open(label_filename, encoding='utf-8')]
     return pd.Index(labels)
 
 
 def save_index_as_labels(index, label_filename):
+    """
+    Save a pandas Index as a text file of labels.
+    """
     with open(label_filename, 'w', encoding='utf-8') as out:
         for label in index:
             print(label, file=out)
-
-
-def load_csr(filename):
-    with np.load(filename) as npz:
-        mat = sparse.csr_matrix((npz['data'], npz['indices'], npz['indptr']), shape=npz['shape'])
-    return mat

--- a/conceptnet5/vectors/formats.py
+++ b/conceptnet5/vectors/formats.py
@@ -118,6 +118,27 @@ def convert_polyglot(polyglot_filename, output_filename, language):
     save_hdf(pg_std, output_filename)
 
 
+def load_glove(filename, max_rows=1000000):
+    """
+    Load a DataFrame from the GloVe text format, which is the same as the
+    fastText format except it doesn't tell you up front how many rows and
+    columns there are.
+    """
+    labels = []
+    rows = []
+    with gzip.open(filename, 'rt') as infile:
+        for i, line in enumerate(infile):
+            if i >= max_rows:
+                break
+            items = line.rstrip().split(' ')
+            labels.append(items[0])
+            values = np.array([float(x) for x in items[1:]], 'f')
+            rows.append(values)
+
+    arr = np.vstack(rows)
+    return pd.DataFrame(arr, index=labels, dtype='f')
+
+
 def load_fasttext(filename, max_rows=1000000):
     """
     Load a DataFrame from the fastText text format.


### PR DESCRIPTION
I needed to be able to export a simple text file of ConceptNet Numberbatch, so I fixed up the `export_text` function. While I was at it, I cleaned up and documented the rest of `conceptnet5.vectors.formats`, including loading GloVe similarly to fastText instead of using Pandas' wonky CSV reader.

I added this all to the test build process, including retrofitting onto a 5000-row version of GloVe.