### PR TITLE
Disable rate limit when not requested by the environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - CONCEPTNET_DB_HOSTNAME=db
       - CONCEPTNET_BUILD_DATA=/data/conceptnet
       - CONCEPTNET_DATA=/data/conceptnet
+      - CONCEPTNET_RATE_LIMITING=0
     volumes:
       - cn5data:/data/conceptnet
       - nginx:/data/nginx

--- a/web/conceptnet_web/api.py
+++ b/web/conceptnet_web/api.py
@@ -27,6 +27,9 @@ app = flask.Flask(
     static_folder=STATIC_PATH
 )
 app.config['JSON_AS_ASCII'] = False
+app.config['RATELIMIT_ENABLED'] = os.environ.get('CONCEPTNET_RATE_LIMITING') == '1'
+
+
 for filter_name, filter_func in FILTERS.items():
     app.jinja_env.filters[filter_name] = filter_func
 app.jinja_env.add_extension('jinja2_highlight.HighlightExtension')

--- a/web/conceptnet_web/web.py
+++ b/web/conceptnet_web/web.py
@@ -19,6 +19,7 @@ import os
 app = flask.Flask('conceptnet5_web')
 STATIC_PATH = os.environ.get('CONCEPTNET_WEB_STATIC', os.path.join(app.root_path, 'static'))
 TEMPLATE_PATH = os.environ.get('CONCEPTNET_WEB_TEMPLATES', os.path.join(app.root_path, 'templates'))
+app.config['RATELIMIT_ENABLED'] = os.environ.get('CONCEPTNET_RATE_LIMITING') == '1'
 
 app.config.update({
     'template_folder': TEMPLATE_PATH,


### PR DESCRIPTION
With this change, rate limiting will be disabled unless the `CONCEPTNET_RATE_LIMITING` environment variable is set to "1".

This fixes the problem where people would run their own copy of the ConceptNet API because they hit the rate limit on the public API, only to find that they hit the rate limit on their own copy too.