### PR TITLE
Refactor SQL queries so they don't give up before matching things

### DIFF
--- a/tests/post-build/test_built.py
+++ b/tests/post-build/test_built.py
@@ -42,3 +42,28 @@ def test_datasets_exist():
         # Test that each dataset has at least 100 assertions
         q = test_finder.query({'dataset': dataset}, limit=100)
         assert len(q) == 100, dataset
+
+# Queries that all include the result "/r/Synonym/,/c/es/prueba/n/,/c/en/test/n/"
+TEST_QUERIES = [
+    {'node': '/c/en/test', 'other': '/c/es'},
+    {'node': '/c/es', 'other': '/c/en/test'},
+    {'start': '/c/es', 'end': '/c/en'},
+    {'node': '/c/es/prueba/n'},
+    {'node': '/c/es/prueba/n', 'source': '/s/resource/wordnet/rdf/3.1'},
+    {'node': '/c/en/test', 'rel': '/r/Synonym', 'other': '/c/es/prueba'},
+]
+TEST_URI = "/a/[/r/Synonym/,/c/es/prueba/n/,/c/en/test/n/]"
+
+
+def check_query(query):
+    q = test_finder.query(query)
+    q_uris = [match['@id'] for match in q]
+    q_uris_set = set(q_uris)
+    assert len(q_uris) == len(q_uris_set)
+    assert TEST_URI in q_uris_set, q_uris_set
+
+
+def test_queries():
+    # Test that each of the above queries finds the expected assertion
+    for query in TEST_QUERIES:
+        yield check_query, query


### PR DESCRIPTION
We used to be pruning prefix matches to the first 200 matching nodes. This totally doesn't work if you're trying to filter for nodes in a particular language, as there are clearly going to be more than 200 nodes matching that prefix.

If we simplify the query, we don't need to do this pruning. The limit at the end of 10000 results is enough to convince PostgreSQL's query planner to do something reasonable, it seems, without having to throw out valid matches.

A few queries take many seconds, such as {'node': '/c/en', 'other': '/c/fr'}. But the API responses for these queries will be cached, and then we're okay.

Fixes #89.