### PR TITLE
Bug in `standardize_row_labels`

### DIFF
--- a/conceptnet5/nodes.py
+++ b/conceptnet5/nodes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 This module constructs URIs for nodes (concepts) in various languages. This
 puts the tools in conceptnet5.uri together with functions that normalize


### PR DESCRIPTION
Double standardization results in non-standard (e.g. /c//en_term) URIs.