### PR TITLE
Standardize cleanup

### DIFF
--- a/conceptnet5/nodes.py
+++ b/conceptnet5/nodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module constructs URIs for nodes (concepts) in various languages. This
 puts the tools in conceptnet5.uri together with functions that normalize

--- a/conceptnet5/vectors/transforms.py
+++ b/conceptnet5/vectors/transforms.py
@@ -13,30 +13,19 @@ def standardize_row_labels(frame, language='en', forms=True):
     (e.g. of the form '/c/en/term'; and with some extra word2vec-style
     normalization of digits). Rows whose labels get the same standardized
     URI get combined, with earlier rows given more weight.
-    Args:
-        frame (DataFrame): Term vectors DataFrame with indexed with terms.
-        language (str, default='en): Use this language for labels that aren't
-            already standardized.
-        forms (bool, default=True): Combine terms with the same lemma.
     """
-    # Re-label the DataFrame with standardized, non-unique row labels
-    # (this used to be a bug, see previous and new behavior comment below)
-    #if all('/' in label for label in frame.index[10:20]):
+    # Check for en/term format we use to train fastText on OpenSubtitles data
     if all(label.count('/') == 1 for label in frame.index[10:20]):
-
-        # previously partitioned label='/c/en/term' into tuple=('', '/', 'c/en/term')
-        # into new label='/c//en_term', now partitions label='en/term' into tuple=('en',
-        # '/', 'term') into new label=/c/en/term
         tuples = [label.partition('/') for label in frame.index]
         frame.index = [uri_prefix(standardized_uri(language, text))
                        for language, _slash, text in tuples]
 
-    # `language` argument is only used here for labels that aren't already standardized
+    # Re-label the DataFrame with standardized, non-unique row labels
     frame.index = [uri_prefix(standardized_uri(language, label)) for label in frame.index]
 
     # Assign row n a weight of 1/(n+1) for weighted averaging
     nrows = frame.shape[0]
-    weights = 1.0 / np.arange(1, nrows + 1)  # "with earlier rows given more weight"
+    weights = 1.0 / np.arange(1, nrows + 1)
     label_weights = pd.Series(weights, index=frame.index)
 
     # groupby(level=0).sum() means to add rows that have the same label


### PR DESCRIPTION
Minor style cleanups. 

I also noticed that `make_replacements` in `transforms.py` is not used, so I'm going to delete it, unless there is a reason to keep it around.