### PR TITLE
Better slashes

### DIFF
--- a/conceptnet5/vectors/__init__.py
+++ b/conceptnet5/vectors/__init__.py
@@ -4,12 +4,11 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import normalize
 
-from conceptnet5.languages import ALL_LANGUAGES
 from conceptnet5.nodes import standardized_concept_uri, uri_to_label
 
 DOUBLE_DIGIT_RE = re.compile(r'[0-9][0-9]')
 DIGIT_RE = re.compile(r'[0-9]')
-CONCEPT_RE = re.compile(r'/c/({})/.+'.format('|'.join(ALL_LANGUAGES)))
+CONCEPT_RE = re.compile(r'/c/[a-z]{2,3}/.+')
 
 
 def replace_numbers(s):

--- a/conceptnet5/vectors/__init__.py
+++ b/conceptnet5/vectors/__init__.py
@@ -1,13 +1,15 @@
-from conceptnet5.nodes import standardized_concept_uri, uri_to_label
-from conceptnet5.language.lemmatize import lemmatize_uri
-from sklearn.preprocessing import normalize
 import re
-import pandas as pd
-import numpy as np
 
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import normalize
+
+from conceptnet5.languages import ALL_LANGUAGES
+from conceptnet5.nodes import standardized_concept_uri, uri_to_label
 
 DOUBLE_DIGIT_RE = re.compile(r'[0-9][0-9]')
 DIGIT_RE = re.compile(r'[0-9]')
+CONCEPT_RE = re.compile(r'/c/({})/.+'.format('|'.join(ALL_LANGUAGES)))
 
 
 def replace_numbers(s):
@@ -33,7 +35,7 @@ def standardized_uri(language, term):
     ConceptNet URI in the given language, and then have its sequences of digits
     replaced.
     """
-    if not (term.startswith('/c/') and term.count('/') >= 2):
+    if not CONCEPT_RE.match(term):
         term = standardized_concept_uri(language, term)
     return replace_numbers(term)
 

--- a/conceptnet5/vectors/__init__.py
+++ b/conceptnet5/vectors/__init__.py
@@ -33,7 +33,7 @@ def standardized_uri(language, term):
     ConceptNet URI in the given language, and then have its sequences of digits
     replaced.
     """
-    if not (term.startswith('/') and term.count('/') >= 2):
+    if not (term.startswith('/c/') and term.count('/') >= 2):
         term = standardized_concept_uri(language, term)
     return replace_numbers(term)
 

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -190,7 +190,7 @@ class VectorSpaceWrapper(object):
     def text_to_vector(self, language, text):
         """Used in Story Cloze Test to create a vector for text """
         tokens = wordfreq.tokenize(text, language)
-        weighted_terms = [(standardized_uri(language, token), 1.) for token in tokens]
+        weighted_terms = [(uri_prefix(standardized_uri(language, token)), 1.) for token in tokens]
         return self.get_vector(weighted_terms, include_neighbors=False)
 
     def get_vector(self, query, include_neighbors=True):


### PR DESCRIPTION
This fixes the situation when terms like '/', '///', '//alexa', and '/sports/the_other_manning' wouldn't be turned into the standardized concept uri form because `term.startswith('/') and term.count('/') >= 2` evaluated to `True` for them.