### PR TITLE
Fixmes and todos, mostly in conceptnet5.vectors

### DIFF
--- a/conceptnet5/language/token_utils.py
+++ b/conceptnet5/language/token_utils.py
@@ -1,15 +1,13 @@
 # coding: utf-8
-from __future__ import unicode_literals
 """
 This file contains some generally useful operations you would perform to
 separate and join tokens. The tools apply most to English, but should also
 be able to do their job in any Western language that uses spaces.
 """
+from __future__ import unicode_literals
 
-# FIXME: this exists only to be imported
-from wordfreq import simple_tokenize
-import sys
 import re
+import sys
 
 PY2 = (sys.version_info.major < 3)
 

--- a/conceptnet5/nodes.py
+++ b/conceptnet5/nodes.py
@@ -4,12 +4,14 @@ puts the tools in conceptnet5.uri together with functions that normalize
 terms and languages into a standard form.
 """
 
-from conceptnet5.language.english import english_filter
-from conceptnet5.language.token_utils import simple_tokenize
-from conceptnet5.uri import concept_uri, split_uri, uri_prefix, parse_possible_compound_uri
-from urllib.parse import urlparse
-from .languages import LCODE_ALIASES
 import re
+from urllib.parse import urlparse
+
+from wordfreq import simple_tokenize
+
+from conceptnet5.language.english import english_filter
+from conceptnet5.uri import concept_uri, split_uri, uri_prefix, parse_possible_compound_uri
+from .languages import LCODE_ALIASES
 
 
 def standardize_text(text, token_filter=None):

--- a/conceptnet5/nodes.py
+++ b/conceptnet5/nodes.py
@@ -10,7 +10,8 @@ from urllib.parse import urlparse
 from wordfreq import simple_tokenize
 
 from conceptnet5.language.english import english_filter
-from conceptnet5.uri import concept_uri, split_uri, uri_prefix, parse_possible_compound_uri
+from conceptnet5.uri import concept_uri, split_uri, uri_prefix, parse_possible_compound_uri, \
+    get_language
 from .languages import LCODE_ALIASES
 
 
@@ -158,7 +159,11 @@ def valid_concept_name(text):
 
 
 def uri_to_label(uri):
-    # FIXME: add docstring
+    """
+    Convert a ConceptNet uri into a label to be used in nodes. This
+    function replaces an underscore with a space, so while '/c/en/example' will be converted into
+    'example', '/c/en/canary_islands' will be converted into 'canary islands'.
+    """
     if uri.startswith('/c/'):
         uri = uri_prefix(uri)
     return uri.split('/')[-1].replace('_', ' ')
@@ -176,8 +181,7 @@ def ld_node(uri, label=None):
     }
     if uri.startswith('/c/'):
         pieces = split_uri(uri)
-        # FIXME: use the function we have to extract the language
-        ld['language'] = pieces[1]
+        ld['language'] = get_language(uri)
         if len(pieces) > 3:
             ld['sense_label'] = '/'.join(pieces[3:])
         ld['term'] = uri_prefix(uri)

--- a/conceptnet5/readers/conceptnet4.py
+++ b/conceptnet5/readers/conceptnet4.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 This script reads the ConceptNet 4 data out of the flat files in raw_data,
 and builds ConceptNet 5 edges from the data.
 """
+from wordfreq import simple_tokenize
 
 from conceptnet5.formats.json_stream import read_json_stream
 from conceptnet5.formats.msgpack_stream import MsgpackStreamWriter
@@ -11,7 +12,6 @@ from conceptnet5.nodes import (
 )
 from conceptnet5.edges import make_edge
 from conceptnet5.language.english import english_filter
-from conceptnet5.language.token_utils import simple_tokenize
 from conceptnet5.uri import join_uri, Licenses
 
 # bedume is a prolific OMCS contributor who seemed to go off the rails at some

--- a/conceptnet5/readers/opencyc.py
+++ b/conceptnet5/readers/opencyc.py
@@ -7,14 +7,17 @@ which is allowed. We just use .nq because it's a more modern format that isn't
 limited to ASCII.)
 """
 
-from conceptnet5.uri import Licenses
-from conceptnet5.nodes import standardized_concept_uri
+from collections import defaultdict
+
+from wordfreq import simple_tokenize
+
 from conceptnet5.edges import make_edge
 from conceptnet5.formats.msgpack_stream import MsgpackStreamWriter
 from conceptnet5.formats.semantic_web import resource_name, parse_nquads
-from conceptnet5.language.token_utils import un_camel_case, simple_tokenize
+from conceptnet5.language.token_utils import un_camel_case
+from conceptnet5.nodes import standardized_concept_uri
 from conceptnet5.readers.conceptnet4 import filter_stopwords
-from collections import defaultdict
+from conceptnet5.uri import Licenses
 
 SOURCE = {'contributor': '/s/resource/opencyc/2012'}
 RDF_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label'

--- a/conceptnet5/uri.py
+++ b/conceptnet5/uri.py
@@ -319,6 +319,10 @@ def is_absolute_url(uri):
     return uri.startswith('http') or uri.startswith('cc:')
 
 
+def get_language(uri):
+    return uri.split('/')[2]
+
+
 class Licenses:
     cc_attribution = 'cc:by/4.0'
     cc_sharealike = 'cc:by-sa/4.0'

--- a/conceptnet5/vectors/__init__.py
+++ b/conceptnet5/vectors/__init__.py
@@ -67,7 +67,7 @@ def normalize_vec(vec):
     L2-normalize a single vector, as a 1-D ndarray or a Series.
     """
     if isinstance(vec, pd.Series):
-        return normalize(vec.fillna(0).reshape(1, -1))[0]
+        return normalize(vec.fillna(0).values.reshape(1, -1))[0]
     elif isinstance(vec, np.ndarray):
         return normalize(vec.reshape(1, -1))[0]
     else:

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -202,11 +202,12 @@ class VectorSpaceWrapper(object):
         will allow expanded_vector to look up neighboring terms in ConceptNet.
         """
         self.load()
-        # FIXME: is pd.DataFrame supposed to be pd.Series here?
         if isinstance(query, np.ndarray):
             return query
-        elif isinstance(query, pd.DataFrame) or isinstance(query, dict):
+        elif isinstance(query, pd.Series) or isinstance(query, dict):
             terms = list(query.items())
+        elif isinstance(query, pd.DataFrame):
+            terms = list(query.to_records())
         elif isinstance(query, str):
             terms = [(query, 1.)]
         elif isinstance(query, list):
@@ -222,7 +223,8 @@ class VectorSpaceWrapper(object):
         Get a Series of terms ranked by their similarity to the query.
         The query can be:
 
-        - A DataFrame of weighted terms
+        - A pandas Series of weighted terms
+        - A pandas DataFrame of weighted terms
         - A dictionary from terms to weights
         - A list of (term, weight) tuples
         - A single term
@@ -230,9 +232,6 @@ class VectorSpaceWrapper(object):
 
         If the query contains 5 or fewer terms, it will be expanded to include
         neighboring terms in ConceptNet.
-
-        TODO: is this sometimes returning a DataFrame? Should it accept a
-        Series as well as a DataFrame?
         """
         self.load()
         vec = self.get_vector(query)

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -239,8 +239,6 @@ class VectorSpaceWrapper(object):
         search_frame = self.small_frame
         if filter:
             exact_only = filter.count('/') >= 3
-            # TODO: Is this duplicating something that field_match was supposed
-            # to do?
             if filter.endswith('/.'):
                 filter = filter[:-2]
                 exact_only = True

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -12,7 +12,7 @@ from conceptnet5.vectors import (
 )
 from conceptnet5.vectors.transforms import l2_normalize_rows
 from conceptnet5.db.query import AssertionFinder
-from conceptnet5.uri import uri_prefix
+from conceptnet5.uri import uri_prefix, get_language, split_uri
 
 # Magnitudes smaller than this tell us that we didn't find anything meaningful
 SMALL = 1e-6
@@ -146,9 +146,8 @@ class VectorSpaceWrapper(object):
                     expanded.append((neighbor, neighbor_weight))
 
                 prefix_weight = 0.01
-                if not term.startswith('/c/en/'):
-                    # FIXME: better language code handling
-                    englishified = '/c/en/' + term[6:]
+                if get_language(term) != 'en':
+                    englishified = '/c/en/' + split_uri(term)[2]
                     expanded.append((englishified, prefix_weight))
 
                 while term:

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -1,18 +1,17 @@
-import wordfreq
-import pandas as pd
-import numpy as np
 import marisa_trie
-import struct
+import numpy as np
+import pandas as pd
+import wordfreq
 
+from conceptnet5.db.query import AssertionFinder
+from conceptnet5.uri import uri_prefix, get_language, split_uri
 from conceptnet5.util import get_data_filename
-from conceptnet5.vectors.formats import load_hdf
 from conceptnet5.vectors import (
     similar_to_vec, weighted_average, normalize_vec, cosine_similarity,
     standardized_uri
 )
+from conceptnet5.vectors.formats import load_hdf
 from conceptnet5.vectors.transforms import l2_normalize_rows
-from conceptnet5.db.query import AssertionFinder
-from conceptnet5.uri import uri_prefix, get_language, split_uri
 
 # Magnitudes smaller than this tell us that we didn't find anything meaningful
 SMALL = 1e-6

--- a/conceptnet5/vectors/sparse_matrix_builder.py
+++ b/conceptnet5/vectors/sparse_matrix_builder.py
@@ -1,6 +1,6 @@
 from scipy import sparse
 import pandas as pd
-from conceptnet5.uri import uri_prefixes, uri_prefix
+from conceptnet5.uri import uri_prefixes, uri_prefix, get_language
 from conceptnet5.nodes import standardized_concept_uri
 from conceptnet5.relations import SYMMETRIC_RELATIONS
 from conceptnet5.languages import CORE_LANGUAGES
@@ -83,10 +83,6 @@ def build_from_conceptnet_table(filename, orig_index=(), self_loops=True):
     shape = (len(labels), len(labels))
     index = pd.Index(labels)
     return mat.tocsr(shape), index
-
-
-def get_language(uri):
-    return uri.split('/')[2]
 
 
 def build_features_from_conceptnet_table(filename):


### PR DESCRIPTION
In `conceptnet5/language/token_utils.py`, should we still be importing unicode_literals?

With these changes, conceptnet5.vectors now has only three TODOs, on which I need additional input.