### PR TITLE
Changes to retrofitting (extracted from visualization branch)

### DIFF
--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -486,7 +486,7 @@ def de_bias_binary(frame, pos_examples, neg_examples, left_examples, right_examp
 
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
-    return l2_normalize_rows(original_component + modified_component)
+    return l2_normalize_rows(original_component + modified_component, offset=1e-9)
 
 
 def de_bias_category(frame, category_examples, bias_examples):
@@ -529,7 +529,7 @@ def de_bias_category(frame, category_examples, bias_examples):
 
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
-    return l2_normalize_rows(original_component + modified_component)
+    return l2_normalize_rows(original_component + modified_component, offset=1e-9)
 
 
 def de_bias_frame(frame):

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.preprocessing import normalize
 from .sparse_matrix_builder import build_from_conceptnet_table
 from .formats import load_hdf, save_hdf
-from sklearn.preprocessing import normalize
+from collections import defaultdict
 
 
 def sharded_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
@@ -74,10 +74,8 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
     (This is an awkward form of input, but unfortunately there is no good
     way to represent sparse labeled data in Pandas.)
 
-    See cli.py for an example of how to build `row_labels` and `sparse_csr`
+    `sharded_retrofit` is responsible for building `row_labels` and `sparse_csr`
     appropriately.
-
-    FIXME: there isn't actually an example there.
     """
     # Initialize a DataFrame with rows that we know
     retroframe = pd.DataFrame(
@@ -89,9 +87,20 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
     weight_array = orig_weights.values[:, np.newaxis].astype('f')
     orig_vecs = retroframe.fillna(0).values
 
+    # Divide up the labels by what language they're in -- we'll use this to
+    # subtract the mean of each language, reducing clumping by language and
+    # improving multilingual alignment.
+    rows_by_language = defaultdict(list)
+    for i, label in enumerate(row_labels):
+        lang = label.split('/')[2]
+        rows_by_language[lang].append(i)
+    all_languages = sorted(rows_by_language)
+    row_groups = [rows_by_language[lang] for lang in all_languages]
+
     # Subtract the mean so that vectors don't just clump around common
     # hypernyms
-    orig_vecs -= orig_vecs.mean(0)
+    for row_group in row_groups:
+        orig_vecs[row_group] -= orig_vecs[row_group].mean(0)
 
     # Delete the frame we built, we won't need its indices again until the end
     del retroframe
@@ -102,7 +111,8 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
             print('Retrofitting: Iteration %s of %s' % (iteration+1, iterations))
 
         vecs = sparse_csr.dot(vecs)
-        vecs -= vecs.mean(0)
+        for row_group in row_groups:
+            orig_vecs[row_group] -= orig_vecs[row_group].mean(0)
 
         # use sklearn's normalize, because it normalizes in place and
         # leaves zero-rows at 0


### PR DESCRIPTION
The visualization revealed to me that our inter-language alignment was not as good as it could be.

In this branch, during retrofitting, instead of just subtracting the mean vector, we subtract the mean vector by language.

Trying to test this revealed a problem with the small test build, which is that many word vectors used in debiasing would end up as NaN due to having no test data. We now use `offset=` when normalizing in de-biasing, so that they end up as the zero vector instead.