### PR TITLE
Reduce memory usage of ConceptNet build

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -524,7 +524,7 @@ rule convert_lexvec:
     resources:
         ram=16
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 1000000 {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
 
 rule convert_opensubtitles_ft:
     input:
@@ -534,7 +534,7 @@ rule convert_opensubtitles_ft:
     resources:
         ram=16
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 1000000 {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
 
 rule convert_polyglot:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -492,7 +492,7 @@ rule convert_word2vec:
     output:
         DATA + "/vectors/w2v-google-news.h5"
     resources:
-        ram=16
+        ram=24
     shell:
         "CONCEPTNET_DATA=data cn5-vectors convert_word2vec -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
 
@@ -502,7 +502,7 @@ rule convert_glove:
     output:
         DATA + "/vectors/glove12-840B.h5"
     resources:
-        ram=16
+        ram=24
     shell:
         "CONCEPTNET_DATA=data cn5-vectors convert_glove -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
 
@@ -512,7 +512,7 @@ rule convert_fasttext:
     output:
         DATA + "/vectors/fasttext-wiki-{lang}.h5"
     resources:
-        ram=16
+        ram=24
     shell:
         "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} -l {wildcards.lang} {input} {output}"
 
@@ -522,7 +522,7 @@ rule convert_lexvec:
     output:
         DATA + "/vectors/lexvec-commoncrawl.h5"
     resources:
-        ram=16
+        ram=24
     shell:
         "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
 
@@ -532,7 +532,7 @@ rule convert_opensubtitles_ft:
     output:
         DATA + "/vectors/fasttext-opensubtitles.h5"
     resources:
-        ram=16
+        ram=24
     shell:
         "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
 
@@ -569,7 +569,7 @@ rule join_retrofit:
     output:
         DATA + "/vectors/{name}-retrofit.h5"
     resources:
-        ram=16
+        ram=24
     shell:
         "cn5-vectors join_retrofit -s {RETROFIT_SHARDS} {output}"
 
@@ -580,7 +580,7 @@ rule merge_intersect:
         DATA + "/vectors/numberbatch-biased.h5",
         DATA + "/vectors/intersection-projection.h5"
     resources:
-        ram=16
+        ram=24
     shell:
         "cn5-vectors intersect {input} {output}"
 

--- a/Snakefile
+++ b/Snakefile
@@ -524,7 +524,7 @@ rule convert_lexvec:
     resources:
         ram=16
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 2000000 {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 1000000 {input} {output}"
 
 rule convert_opensubtitles_ft:
     input:
@@ -534,7 +534,7 @@ rule convert_opensubtitles_ft:
     resources:
         ram=16
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 2000000 {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 1000000 {input} {output}"
 
 rule convert_polyglot:
     input:

--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -486,7 +486,7 @@ def de_bias_binary(frame, pos_examples, neg_examples, left_examples, right_examp
 
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
-    return l2_normalize_rows(original_component + modified_component)
+    return l2_normalize_rows(original_component + modified_component, offset=1e-9)
 
 
 def de_bias_category(frame, category_examples, bias_examples):
@@ -529,7 +529,7 @@ def de_bias_category(frame, category_examples, bias_examples):
 
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
-    return l2_normalize_rows(original_component + modified_component)
+    return l2_normalize_rows(original_component + modified_component, offset=1e-9)
 
 
 def de_bias_frame(frame):

--- a/conceptnet5/vectors/merge.py
+++ b/conceptnet5/vectors/merge.py
@@ -2,6 +2,7 @@
 import pandas as pd
 import numpy as np
 from conceptnet5.languages import CORE_LANGUAGES
+from conceptnet5.uri import get_language
 from .transforms import l2_normalize_rows
 from .formats import save_hdf
 
@@ -27,10 +28,17 @@ def dataframe_svd_projection(frame, k):
 
 
 def merge_intersect(frames, subsample=20, vocab_cutoff=200000, k=300):
-    joined = pd.concat(frames, join='inner', axis=1, ignore_index=True).astype('f')
+    label_intersection = set(frames[0].index)
+    for frame in frames[1:]:
+        label_intersection &= set(frame.index)
+    filtered_labels = pd.Series(
+        [label for label in sorted(label_intersection)
+         if '_' not in label and get_language(label) in CORE_LANGUAGES]
+    )
+    frames = [frame.loc[filtered_labels].astype('f') for frame in frames]
+    joined = pd.concat(frames, join='inner', axis=1, ignore_index=True)
     joined.fillna(0.)
-    filtered_labels = pd.Series([label for label in joined.index if '_' not in label and label.split('/')[2] in CORE_LANGUAGES])
-    adjusted = l2_normalize_rows(joined.loc[filtered_labels].ix[::subsample] - joined.mean(0))
+    adjusted = l2_normalize_rows(joined.ix[::subsample] - joined.mean(0))
 
     # Search the frames for significant terms that we've missed.
     # Significant terms are those that appear in 3 different vocabularies,

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.preprocessing import normalize
 from .sparse_matrix_builder import build_from_conceptnet_table
 from .formats import load_hdf, save_hdf
-from sklearn.preprocessing import normalize
+from collections import defaultdict
 
 
 def sharded_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
@@ -74,10 +74,8 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
     (This is an awkward form of input, but unfortunately there is no good
     way to represent sparse labeled data in Pandas.)
 
-    See cli.py for an example of how to build `row_labels` and `sparse_csr`
+    `sharded_retrofit` is responsible for building `row_labels` and `sparse_csr`
     appropriately.
-
-    FIXME: there isn't actually an example there.
     """
     # Initialize a DataFrame with rows that we know
     retroframe = pd.DataFrame(
@@ -89,9 +87,20 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
     weight_array = orig_weights.values[:, np.newaxis].astype('f')
     orig_vecs = retroframe.fillna(0).values
 
+    # Divide up the labels by what language they're in -- we'll use this to
+    # subtract the mean of each language, reducing clumping by language and
+    # improving multilingual alignment.
+    rows_by_language = defaultdict(list)
+    for i, label in enumerate(row_labels):
+        lang = label.split('/')[2]
+        rows_by_language[lang].append(i)
+    all_languages = sorted(rows_by_language)
+    row_groups = [rows_by_language[lang] for lang in all_languages]
+
     # Subtract the mean so that vectors don't just clump around common
     # hypernyms
-    orig_vecs -= orig_vecs.mean(0)
+    for row_group in row_groups:
+        orig_vecs[row_group] -= orig_vecs[row_group].mean(0)
 
     # Delete the frame we built, we won't need its indices again until the end
     del retroframe
@@ -102,7 +111,8 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
             print('Retrofitting: Iteration %s of %s' % (iteration+1, iterations))
 
         vecs = sparse_csr.dot(vecs)
-        vecs -= vecs.mean(0)
+        for row_group in row_groups:
+            orig_vecs[row_group] -= orig_vecs[row_group].mean(0)
 
         # use sklearn's normalize, because it normalizes in place and
         # leaves zero-rows at 0

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.preprocessing import normalize
 from .sparse_matrix_builder import build_from_conceptnet_table
 from .formats import load_hdf, save_hdf
+from conceptnet5.uri import get_language
 from collections import defaultdict
 
 
@@ -92,7 +93,7 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
     # improving multilingual alignment.
     rows_by_language = defaultdict(list)
     for i, label in enumerate(row_labels):
-        lang = label.split('/')[2]
+        lang = get_language(label)
         rows_by_language[lang].append(i)
     all_languages = sorted(rows_by_language)
     row_groups = [rows_by_language[lang] for lang in all_languages]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/bin/bash -x
+pip install -e '.[vectors]'
 snakemake --resources 'ram=16' -j

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -x
 pip install -e '.[vectors]'
-snakemake --resources 'ram=16' -j
+snakemake --resources 'ram=24' -j


### PR DESCRIPTION
There may have once been a time when ConceptNet could be built in 16 GB of RAM. That time isn't now. But we should try to keep the RAM usage somewhat under control so that not everyone needs to have a 64 GB machine.

A couple of steps in particular were using unreasonable amounts of RAM, such as `merge_intersect` which was using more than 30 GB. By pre-allocating some matrices (instead of copying) and changing the order that we do some steps, we can reduce the memory usage.

I believe the build requires about 24 GB of RAM, and I've changed the RAM constraints defined in the Snakefile to reflect this.