### PR TITLE
Fewer print statements during the build process

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -561,7 +561,7 @@ rule retrofit:
     resources:
         ram=16
     shell:
-        "cn5-vectors retrofit -s {RETROFIT_SHARDS} -v {input} %(data)s/vectors/{wildcards.name}-retrofit.h5" % {'data': DATA}
+        "cn5-vectors retrofit -s {RETROFIT_SHARDS} {input} %(data)s/vectors/{wildcards.name}-retrofit.h5" % {'data': DATA}
 
 rule join_retrofit:
     input:

--- a/conceptnet5/db/prepare_data.py
+++ b/conceptnet5/db/prepare_data.py
@@ -111,7 +111,6 @@ def load_sql_csv(connection, input_dir):
         (input_dir + '/node_prefixes.csv', 'node_prefixes'),
         (input_dir + '/edge_features.csv', 'edge_features')
     ]:
-        print(filename)
         cursor = connection.cursor()
         with open(filename, 'rb') as file:
             cursor.execute("COPY %s FROM STDIN" % tablename, stream=file)

--- a/conceptnet5/db/schema.py
+++ b/conceptnet5/db/schema.py
@@ -82,7 +82,6 @@ INDICES = [
 def run_commands(connection, commands):
     cursor = connection.cursor()
     for cmd in commands:
-        print(cmd)
         cursor.execute(cmd)
     connection.commit()
 

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -40,13 +40,13 @@ def filter_word_vectors(dense_hdf_filename, vocab_filename):
 @click.argument('conceptnet_filename', type=click.Path(readable=True, dir_okay=False))
 @click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
 @click.option('--iterations', '-i', default=5)
-@click.option('--verbose', '-v', count=True)
 @click.option('--nshards', '-s', default=6)
+@click.option('--verbose', '-v', count=True)
 def run_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
-                 iterations=5, nshards=6, verbose=1):
+                 iterations=5, nshards=6, verbose=0):
     sharded_retrofit(
         dense_hdf_filename, conceptnet_filename, output_filename,
-        iterations=iterations, nshards=nshards, verbose=verbose
+        iterations=iterations, nshards=nshards, verbosity=verbose
     )
 
 

--- a/conceptnet5/vectors/merge.py
+++ b/conceptnet5/vectors/merge.py
@@ -45,7 +45,6 @@ def merge_intersect(frames, subsample=20, vocab_cutoff=200000, k=300):
     # or in 2 different vocabularies and in the first `vocab_cutoff` rows of
     # one of them.
 
-    print('Finding expanded vocabulary')
     vocabulary = frames[0].index
     for frame in frames[1:]:
         vocabulary |= frame.index
@@ -56,7 +55,6 @@ def merge_intersect(frames, subsample=20, vocab_cutoff=200000, k=300):
     new_terms = vocabulary[term_scores >= 3].difference(joined.index)
     new_vecs = [frame.reindex(new_terms) for frame in frames]
 
-    print('Building input matrix with expanded vocabulary')
     joined2 = pd.concat([
         joined,
         pd.concat(new_vecs, join='outer', axis=1, ignore_index=True).astype('f').fillna(0.)
@@ -65,11 +63,8 @@ def merge_intersect(frames, subsample=20, vocab_cutoff=200000, k=300):
     del new_vecs
     projected, eigenvalues, projection = dataframe_svd_projection(adjusted, k)
     del adjusted
-
-    print('Saving results in /tmp')
     del projected
 
-    print('Projecting vocabulary into new space')
     reprojected = joined2.dot(projection)
     reprojected /= (eigenvalues ** .5)
     del joined2

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 
 
 def sharded_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
-                     iterations=5, nshards=6, verbose=1):
+                     iterations=5, nshards=6, verbosity=0):
     # frame_box is basically a reference to a single large DataFrame. The
     # DataFrame will at times be present or absent. When it's present, the list
     # contains one item, which is the DataFrame. When it's absent, the list
@@ -29,7 +29,7 @@ def sharded_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
         # up a lot of memory and we can reload it from disk later.
         frame_box.clear()
 
-        retrofitted = retrofit(combined_index, dense_frame, sparse_csr, iterations, verbose)
+        retrofitted = retrofit(combined_index, dense_frame, sparse_csr, iterations, verbosity)
         save_hdf(retrofitted, temp_filename)
         del retrofitted
 
@@ -51,7 +51,7 @@ def join_shards(output_filename, nshards=6):
     save_hdf(dframe, output_filename)
 
 
-def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=1):
+def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=0):
     """
     Retrofitting is a process of combining information from a machine-learned
     space of term vectors with further structured information about those


### PR DESCRIPTION
At first I was just removing the no-longer-applicable statement about "Saving results in /tmp", but I went and removed a lot more while I was at it, especially the 30 repetitive lines with the progress of retrofitting.

I have not yet removed the one that shows the average weight per dataset. That's information that I think we should be using in retrofitting. We're not; it's just getting printed out to no effect. So I would like to leave it there for now as a reminder.