### PR TITLE
Fixes to the vector-space build process

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -69,7 +69,7 @@ INPUT_EMBEDDINGS = [
     'glove12-840B', 'w2v-google-news', 'fasttext-opensubtitles'
 ]
 SOURCE_EMBEDDING_ROWS = 1500000
-MULTILINGUAL_SOURCE_EMBEDDING_ROWS = 2500000
+MULTILINGUAL_SOURCE_EMBEDDING_ROWS = 2000000
 
 # If CONCEPTNET_BUILD_TEST is set, we're running the small test build.
 TESTMODE = bool(os.environ.get("CONCEPTNET_BUILD_TEST"))

--- a/Snakefile
+++ b/Snakefile
@@ -590,7 +590,7 @@ rule debias:
     output:
         DATA + "/vectors/numberbatch.h5"
     resources:
-        ram=16
+        ram=30
     shell:
         "cn5-vectors debias {input} {output}"
 

--- a/Snakefile
+++ b/Snakefile
@@ -69,6 +69,7 @@ INPUT_EMBEDDINGS = [
     'glove12-840B', 'w2v-google-news', 'fasttext-opensubtitles'
 ]
 SOURCE_EMBEDDING_ROWS = 1500000
+MULTILINGUAL_SOURCE_EMBEDDING_ROWS = 2500000
 
 # If CONCEPTNET_BUILD_TEST is set, we're running the small test build.
 TESTMODE = bool(os.environ.get("CONCEPTNET_BUILD_TEST"))
@@ -514,7 +515,7 @@ rule convert_fasttext:
     resources:
         ram=24
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 2500000 -l {wildcards.lang} {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} -l {wildcards.lang} {input} {output}"
 
 rule convert_lexvec:
     input:
@@ -534,7 +535,7 @@ rule convert_opensubtitles_ft:
     resources:
         ram=24
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 2500000 {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {MULTILINGUAL_SOURCE_EMBEDDING_ROWS} {input} {output}"
 
 rule convert_polyglot:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -514,7 +514,7 @@ rule convert_fasttext:
     resources:
         ram=24
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} -l {wildcards.lang} {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 2500000 -l {wildcards.lang} {input} {output}"
 
 rule convert_lexvec:
     input:
@@ -534,7 +534,7 @@ rule convert_opensubtitles_ft:
     resources:
         ram=24
     shell:
-        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n 2500000 {input} {output}"
 
 rule convert_polyglot:
     input:

--- a/build.sh
+++ b/build.sh
@@ -30,4 +30,4 @@ check_db () {
 check_disk_space
 pip install -e '.[vectors]'
 check_db
-snakemake --resources 'ram=24' -j
+snakemake --resources 'ram=30' -j

--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -1,9 +1,9 @@
-from conceptnet5.vectors import standardized_uri, normalize_vec
-from conceptnet5.vectors.transforms import l2_normalize_rows
-import pandas as pd
 import numpy as np
+import pandas as pd
 from sklearn import svm
 from sklearn.preprocessing import normalize
+
+from conceptnet5.vectors import standardized_uri, normalize_vec
 
 
 # A list of English words referring to nationalities, nations, ethnicities, and
@@ -399,8 +399,9 @@ def reject_subspace(frame, vecs):
             projection = current_array.dot(vec)
             np.subtract(current_array, np.outer(projection, vec), out=current_array)
 
+    normalize(current_array, norm='l2', copy=False)
+
     current_array = pd.DataFrame(current_array, index=frame.index)
-    normalize(current_array.values, norm='l2', copy=False)
     current_array.fillna(0, inplace=True)
     return current_array
 

--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -1,7 +1,9 @@
 from conceptnet5.vectors import standardized_uri, normalize_vec
 from conceptnet5.vectors.transforms import l2_normalize_rows
+import pandas as pd
 import numpy as np
 from sklearn import svm
+from sklearn.preprocessing import normalize
 
 
 # A list of English words referring to nationalities, nations, ethnicities, and
@@ -390,14 +392,17 @@ def reject_subspace(frame, vecs):
     its rows have any correlation with any rows of `vecs`, by subtracting
     the outer product of `frame` with each normalized row of `vecs`.
     """
-    current_array = frame.copy()
+    current_array = frame.copy().values
     for vec in vecs:
         if not np.isnan(vec).any():
             vec = normalize_vec(vec)
             projection = current_array.dot(vec)
-            current_array -= np.outer(projection, vec)
+            np.subtract(current_array, np.outer(projection, vec), out=current_array)
 
-    return l2_normalize_rows(current_array, offset=1e-9)
+    normalize(current_array, norm='l2', copy=False)
+    current_array = pd.DataFrame(current_array, index=frame.index)
+    current_array.fillna(0, inplace=True)
+    return current_array
 
 
 def get_vocabulary_vectors(frame, vocab):
@@ -482,11 +487,14 @@ def de_bias_binary(frame, pos_examples, neg_examples, left_examples, right_examp
 
     # Make another component representing the vectors that should not be
     # de-biased: the original space times (1 - applicability).
-    original_component = frame.mul(1 - applicability, axis=0)
+    result = frame.mul(1 - applicability, axis=0)
 
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
-    return l2_normalize_rows(original_component + modified_component, offset=1e-9)
+    np.add(result.values, modified_component.values, out=result.values)
+    normalize(result.values, norm='l2', copy=False)
+    del modified_component
+    return result
 
 
 def de_bias_category(frame, category_examples, bias_examples):
@@ -511,6 +519,7 @@ def de_bias_category(frame, category_examples, bias_examples):
     # Predict the probability of each word in the vocabulary being in the
     # category.
     applicability = category_predictor.predict_proba(frame)[:, 1]
+    del category_predictor
 
     # Make a matrix of vectors representing the correlations to remove.
     vocab = [
@@ -522,14 +531,18 @@ def de_bias_category(frame, category_examples, bias_examples):
     # Then weight each row of that space by "applicability", the probability
     # that each row should be de-biased.
     modified_component = reject_subspace(frame, components_to_reject).mul(applicability, axis=0)
+    del components_to_reject
 
     # Make another component representing the vectors that should not be
     # de-biased: the original space times (1 - applicability).
-    original_component = frame.mul(1 - applicability, axis=0)
+    result = frame.mul(1 - applicability, axis=0)
 
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
-    return l2_normalize_rows(original_component + modified_component, offset=1e-9)
+    np.add(result.values, modified_component.values, out=result.values)
+    normalize(result.values, norm='l2', copy=False)
+    del modified_component
+    return result
 
 
 def de_bias_frame(frame):

--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -399,8 +399,8 @@ def reject_subspace(frame, vecs):
             projection = current_array.dot(vec)
             np.subtract(current_array, np.outer(projection, vec), out=current_array)
 
-    normalize(current_array, norm='l2', copy=False)
     current_array = pd.DataFrame(current_array, index=frame.index)
+    normalize(current_array.values, norm='l2', copy=False)
     current_array.fillna(0, inplace=True)
     return current_array
 
@@ -492,8 +492,10 @@ def de_bias_binary(frame, pos_examples, neg_examples, left_examples, right_examp
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
     np.add(result.values, modified_component.values, out=result.values)
-    normalize(result.values, norm='l2', copy=False)
     del modified_component
+
+    # L_2-normalize the resulting rows in-place.
+    normalize(result.values, norm='l2', copy=False)
     return result
 
 
@@ -540,8 +542,10 @@ def de_bias_category(frame, category_examples, bias_examples):
     # The sum of these two components is the de-biased space, where de-biasing
     # applies to each row proportional to its applicability.
     np.add(result.values, modified_component.values, out=result.values)
-    normalize(result.values, norm='l2', copy=False)
     del modified_component
+
+    # L_2-normalize the resulting rows in-place.
+    normalize(result.values, norm='l2', copy=False)
     return result
 
 

--- a/conceptnet5/vectors/merge.py
+++ b/conceptnet5/vectors/merge.py
@@ -1,8 +1,9 @@
-# coding: utf-8
 import pandas as pd
 import numpy as np
-from conceptnet5.languages import CORE_LANGUAGES
 from sklearn.preprocessing import normalize
+
+from conceptnet5.uri import get_language
+from conceptnet5.languages import CORE_LANGUAGES
 
 
 def dataframe_svd_projection(frame, k):
@@ -90,7 +91,7 @@ def merge_intersect(frames, subsample=20, vocab_cutoff=200000, k=300):
     filtered_labels = pd.Series([
         label for (i, label) in enumerate(joined.index)
         if i % subsample == 0 and '_' not in label
-        and label.split('/')[2] in CORE_LANGUAGES
+        and get_language(label) in CORE_LANGUAGES
     ])
 
     # Mean-center and L_2-normalize the data, to prevent artifacts

--- a/conceptnet5/vectors/merge.py
+++ b/conceptnet5/vectors/merge.py
@@ -2,7 +2,6 @@
 import pandas as pd
 import numpy as np
 from conceptnet5.languages import CORE_LANGUAGES
-from .transforms import l2_normalize_rows
 from sklearn.preprocessing import normalize
 
 
@@ -16,9 +15,6 @@ def dataframe_svd_projection(frame, k):
     k-dimensional vector to each column. One way to think of these is that
     `uframe` contains the rows of `frame` projected into a k-dimensional space,
     while `vframe` is the operation that projects those rows.
-
-    In SVD terms, after `frame` has been factored into U @ Σ @ V^T,
-    `uframe` is U @ sqrt(Σ), and `vframe` is V @ sqrt(Σ).
     """
     U, Σ, Vt = np.linalg.svd(frame.values, full_matrices=False)
     uframe = pd.DataFrame(U[:, :k], index=frame.index, dtype='f')
@@ -27,47 +23,111 @@ def dataframe_svd_projection(frame, k):
 
 
 def concat_intersect(frames):
+    """
+    Find the intersection of the labels of all the `frames`, and concatenate
+    the vectors that the frames have for each of those labels.
+
+    This is exactly what `pd.concat` is for. However, `pd.concat` uses too
+    much memory. We have to emulate what it does while building the result
+    within a single matrix, instead of having multiple intermediate matrices.
+    """
+    # Each frame will be associated with a range of columns in our concatenated
+    # frame. As we scan through the frames, find out what the indices of those
+    # columns are.
     frame_col_offsets = [0]
     ncolumns = frames[0].shape[1]
+
+    # Our label intersection starts out as the label set of the first frame.
     label_intersection = set(frames[0].index)
+
+    # Narrow down the label intersection, and find the column offset of
+    # each subsequent frame.
     for frame in frames[1:]:
         label_intersection &= set(frame.index)
         frame_col_offsets.append(ncolumns)
         ncolumns += frame.shape[1]
+
     nrows = len(label_intersection)
+
+    # Get the list of labels in a predictable order.
     label_intersection = sorted(label_intersection)
 
+    # Now we know how many rows and columns of data we have, so allocate the
+    # NumPy array that will contain our results.
     joindata = np.zeros((nrows, ncolumns), 'f')
+
+    # Find the appropriate rows of each frame, extract them in the order of
+    # our labels, and set those as the appropriate columns of the merged array.
     for frame, offset in zip(frames, frame_col_offsets):
         width = frame.shape[1]
         joindata[:, offset:(offset + width)] = frame.loc[label_intersection].values
+
+    # Convert the array to a DataFrame with the appropriate labels, and
+    # return it.
     joined = pd.DataFrame(joindata, index=label_intersection)
     return joined
 
 
-def concat_union(frames):
-    pass
-
-
 def merge_intersect(frames, subsample=20, vocab_cutoff=200000, k=300):
+    """
+    Combine the vector knowledge contained in `frames` over the vocabulary
+    that they agree on, and use dimensionality reduction to mitigate the
+    redundancy of learning the same thing multiple ways.
+
+    If their vocabularies result from retrofitting, then the resulting
+    vocabulary will be the vocabulary of the retrofit knowledge graph,
+    plus any other terms that happen to be in all of the frames.
+    """
+    # Find the intersected vocabulary of the frames, and concatenate their
+    # vectors over that vocabulary.
     joined = concat_intersect(frames)
+
+    # Find a subset of the labels that we'll use for calculating the
+    # dimensionality-reduced version. The labels we particularly care about
+    # are single words in our CORE_LANGUAGES. Even those are too numerous,
+    # so we take an arbitrary 1/n sample of them, where n is given by the
+    # `subsample` parameter.
     filtered_labels = pd.Series([
         label for (i, label) in enumerate(joined.index)
         if i % subsample == 0 and '_' not in label
         and label.split('/')[2] in CORE_LANGUAGES
     ])
+
+    # Mean-center and L_2-normalize the data, to prevent artifacts
+    # in dimensionality reduction.
     adjusted = joined.loc[filtered_labels]
     adjusted -= joined.mean(0)
     normalize(adjusted.values, norm='l2', copy=False)
 
+    # The SVD of this normalized matrix will give us its projection into
+    # a lower-dimensional space (`projected`), as well as the operator that
+    # performs that projection (`projection`) and the relative weights of the
+    # columns (`eigenvalues`).
     projected, eigenvalues, projection = dataframe_svd_projection(adjusted, k)
+
+    # We don't actually need this smaller matrix or its projection anymore;
+    # what we learned is how to project _any_ matrix into this space.
     del adjusted
     del projected
 
+    # Project the original `joined` matrix into this space using the
+    # `projection` operator.
     reprojected = joined.dot(projection)
     del joined
+
+    # `projection` (V) is an orthogonal matrix, so when we multiply by it, we
+    # get a `reprojected` that approximately preserves distances (U * Σ).
+    #
+    # But these distances reflect redundant features among the input matrices.
+    # To mitigate this redundancy, and to match Levy and Goldberg's observation
+    # that U * Σ ** (1/2) is a better SVD projection for word-representation
+    # purposes than U * Σ, we divide by Σ ** (1/2).
     np.divide(reprojected.values, eigenvalues ** .5, out=reprojected.values)
     normalize(reprojected.values, norm='l2', copy=False)
+
+    # Make sure we didn't divide by zero at any point.
     assert not reprojected.isnull().values.any()
-    reprojected.sort_index(inplace=True)
+
+    # Return our unified vectors, and the projection that could map other
+    # concatenated vectors into the same vector space.
     return reprojected, projection

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -89,7 +89,8 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=0):
 
     # Subtract the mean so that vectors don't just clump around common
     # hypernyms
-    orig_vecs -= orig_vecs.mean(0)
+    nonzero_indices = np.abs(orig_vecs).sum(1).nonzero()
+    orig_vecs[nonzero_indices] -= orig_vecs.mean(0)
 
     # Delete the frame we built, we won't need its indices again until the end
     del retroframe
@@ -100,7 +101,8 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=0):
             print('Retrofitting: Iteration %s of %s' % (iteration+1, iterations))
 
         vecs = sparse_csr.dot(vecs)
-        vecs -= vecs.mean(0)
+        nonzero_indices = np.abs(vecs).sum(1).nonzero()
+        vecs[nonzero_indices] -= vecs.mean(0)
 
         # use sklearn's normalize, because it normalizes in place and
         # leaves zero-rows at 0

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -113,7 +113,7 @@ def retrofit(row_labels, dense_frame, sparse_csr, iterations=5, verbosity=0):
 
         vecs = sparse_csr.dot(vecs)
         for row_group in row_groups:
-            orig_vecs[row_group] -= orig_vecs[row_group].mean(0)
+            vecs[row_group] -= vecs[row_group].mean(0)
 
         # use sklearn's normalize, because it normalizes in place and
         # leaves zero-rows at 0


### PR DESCRIPTION
While my hopes of making this build in a nearly-reasonable 24 GB of RAM must be set aside, I at least made it work in 30 GB. Various array operations are now done in-place instead of making copies of large arrays.

Also fixed some things that were making the vectors not come out as good as ones we've previously released. Language-balancing is gone for now, and the sampling strategy in `merge.py` is back to what it was.