### PR TITLE
Remove a source of gender stereotypes from ConceptNet

### DIFF
--- a/conceptnet5/readers/conceptnet4.py
+++ b/conceptnet5/readers/conceptnet4.py
@@ -97,10 +97,13 @@ CONCEPT_BLACKLIST = {
     '/c/en/when', '/c/en/whether', '/c/en/nothing', '/c/en/nobody',
     '/c/en/no_one',
 
-    # It's not our job to remove all vulgar terms, especially as they may be
-    # important to understand in context. But here are a few that just pollute
-    # the results for no reason.
-    '/c/en/touch_her_cunt', '/c/en/blow_her_boyfriend'
+    # OMCS users tended to give unfortunate, stereotyped answers when asked
+    # about terms distinguished by their gender. As part of the de-biasing
+    # effort, we should skip these. We can learn enough about 'man' and 'woman'
+    # from dictionary definitions and from statements about 'person'.
+    '/c/en/man', '/c/en/woman', '/c/en/boy', '/c/en/girl', '/c/en/boyfriend',
+    '/c/en/girlfriend', '/c/en/brother', '/c/en/sister', '/c/en/mother',
+    '/c/en/father', '/c/en/daughter', '/c/en/son', '/c/en/wife', '/c/en/husband'
 }
 ACTIVITY_BLACKLIST = {
     "20 Questions",
@@ -162,6 +165,7 @@ def can_skip(parts_dict):
     ):
         return True
     return False
+
 
 # TODO: this should be combined with 'can_skip'
 def skip_assertion(source_dict, start, end):

--- a/conceptnet5/readers/conceptnet4.py
+++ b/conceptnet5/readers/conceptnet4.py
@@ -12,6 +12,7 @@ from conceptnet5.nodes import (
 )
 from conceptnet5.edges import make_edge
 from conceptnet5.language.english import english_filter
+from conceptnet5.language.lemmatize import lemmatize_uri
 from conceptnet5.uri import join_uri, Licenses
 
 # bedume is a prolific OMCS contributor who seemed to go off the rails at some
@@ -173,7 +174,7 @@ def skip_assertion(source_dict, start, end):
     Filter out assertions that we can tell will be unhelpful after we've
     extracted them.
     """
-    if start in CONCEPT_BLACKLIST or end in CONCEPT_BLACKLIST:
+    if lemmatize_uri(start) in CONCEPT_BLACKLIST or lemmatize_uri(end) in CONCEPT_BLACKLIST:
         return True
     if source_dict['contributor'] in CONTRIBUTOR_BLACKLIST:
         return True


### PR DESCRIPTION
I had made a furtive attempt to remove some particularly unfortunate statements from the OMCS (ConceptNet 4) data, but a lot more remained.

Looking at the data, I concluded that the best plan was to discard the data for a large number of words that are primarily defined by their gender. For example, asking OMCS users for statements about "man" and "woman" tended to only lead to bad results, compared to statements about "person".

ConceptNet 5 can still understand _definitional_ gender distinctions in words, because it gets those from sources such as WordNet and Wiktionary.

You'll see some problematic terms being _removed_ from the blacklist, because the new filter lets us make sure those don't appear without having to list them explicitly.