### PR TITLE
Modify path for storing checksums

### DIFF
--- a/data-loader/10-check-download.sh
+++ b/data-loader/10-check-download.sh
@@ -3,14 +3,15 @@
 PRECOMPUTED_PSQL_URL=http://conceptnet.s3.amazonaws.com/precomputed-data/2016/psql/5.5.5
 PRECOMPUTED_VECTOR_URL=http://conceptnet.s3.amazonaws.com/precomputed-data/2016/numberbatch/17.06
 DATA=/data/conceptnet
+CHECKSUM=/checksum
 NAMES='edges edge_sources edge_features nodes node_prefixes sources relations'
 
 get_db_files() {
     for name in $NAMES; do
         curl $PRECOMPUTED_PSQL_URL/$name.csv.gz > $DATA/psql/$name.csv.gz
     done
-    sha256sum $DATA/psql/*.csv.gz > $DATA/local/sha256sums.computed.txt
-    diff $DATA/local/sha256sums.txt $DATA/local/sha256sums.computed.txt || panic
+    sha256sum $DATA/psql/*.csv.gz > $CHECKSUM/sha256sums.computed.txt
+    diff $CHECKSUM/sha256sums.txt $CHECKSUM/sha256sums.computed.txt || panic
 }
 
 panic() {

--- a/data-loader/Dockerfile
+++ b/data-loader/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
 ADD 10-check-download.sh /docker-entrypoint-initdb.d/10-check-download.sh
 ADD 20-load-db.sql /docker-entrypoint-initdb.d/20-load-db.sql
 ADD 30-done.sh /docker-entrypoint-initdb.d/30-done.sh
-ADD sha256sums.txt /data/conceptnet/local/sha256sums.txt
+ADD sha256sums.txt /checksum/sha256sums.txt
 
 RUN chown -R root.postgres /data/conceptnet
 RUN chmod -R g+w /data/conceptnet


### PR DESCRIPTION
Since the data-loader Dockerfile adds sha256sums.txt to /data/conceptnet, the checksums are available inside the image in this location.
But, docker-compose.yml mounts a named volume at the same location, i.e. /data/conceptnet
So when the container becomes alive after docker-compose up --build, this volume gets mounted at /data/conceptnet and the checksums file is no longer available
As a result, data-loader/10-check-download.sh fails at line 13-14
In this commit, I have changed the location of checksum file: new location is /checksum, and the same has been updated in the Dockerfile and bash script