### PR TITLE
fix export_text

### DIFF
--- a/conceptnet5/vectors/formats.py
+++ b/conceptnet5/vectors/formats.py
@@ -61,6 +61,7 @@ def export_text(frame, filename, filter_language=None):
         except KeyError:
             end_idx = frame.shape[0]
         frame = frame.iloc[start_idx:end_idx]
+        vectors = frame.values
         index = frame.index
 
     with gzip.open(filename, 'wt') as out:


### PR DESCRIPTION
Added a line for updating the index of vectors. Index of labels and index of vectors don't correspond each other when exporting vectors for a specific language.