### PR TITLE
Use a local socket connection to the ConceptNet database

### DIFF
--- a/conceptnet5/db/config.py
+++ b/conceptnet5/db/config.py
@@ -12,10 +12,6 @@ import os
 
 DB_USERNAME = os.environ.get('CONCEPTNET_DB_USER', os.environ.get('USER', 'postgres'))
 DB_NAME = os.environ.get('CONCEPTNET_DB_NAME', 'conceptnet5')
+DB_PASSWORD = os.environ.get('CONCEPTNET_DB_PASSWORD')
 DB_SOCKET = '/var/run/postgresql/.s.PGSQL.5432'
-
-# These will not be used if DB_PASSWORD is blank -- instead, we'll use DB_SOCKET
-DB_PASSWORD = os.environ.get('CONCEPTNET_DB_PASSWORD', '')
-DB_HOSTNAME = os.environ.get('CONCEPTNET_DB_HOSTNAME', 'localhost')
-DB_PORT = int(os.environ.get('CONCEPTNET_DB_PORT', '5432'))
 

--- a/conceptnet5/db/config.py
+++ b/conceptnet5/db/config.py
@@ -11,7 +11,11 @@ environment variables:
 import os
 
 DB_USERNAME = os.environ.get('CONCEPTNET_DB_USER', os.environ.get('USER', 'postgres'))
+DB_NAME = os.environ.get('CONCEPTNET_DB_NAME', 'conceptnet5')
+DB_SOCKET = '/var/run/postgresql/.s.PGSQL.5432'
+
+# These will not be used if DB_PASSWORD is blank -- instead, we'll use DB_SOCKET
 DB_PASSWORD = os.environ.get('CONCEPTNET_DB_PASSWORD', '')
 DB_HOSTNAME = os.environ.get('CONCEPTNET_DB_HOSTNAME', 'localhost')
 DB_PORT = int(os.environ.get('CONCEPTNET_DB_PORT', '5432'))
-DB_NAME = os.environ.get('CONCEPTNET_DB_NAME', 'conceptnet5')
+

--- a/conceptnet5/db/connection.py
+++ b/conceptnet5/db/connection.py
@@ -42,13 +42,21 @@ def get_db_connection(dbname=None, building=False):
 
 
 def _get_db_connection_inner(dbname):
-    conn = pg8000.connect(
-        user=config.DB_USERNAME,
-        password=config.DB_PASSWORD,
-        host=config.DB_HOSTNAME,
-        port=config.DB_PORT,
-        database=dbname
-    )
+    if not config.DB_PASSWORD:
+        conn = pg8000.connect(
+            user=config.DB_USERNAME,
+            unix_sock=config.DB_SOCKET,
+            database=dbname
+        )
+    else:
+        conn = pg8000.connect(
+            user=config.DB_USERNAME,
+            password=config.DB_PASSWORD,
+            host=config.DB_HOSTNAME,
+            port=config.DB_PORT,
+            database=dbname
+        )
+
     pg8000.paramstyle = 'named'
     return conn
 

--- a/conceptnet5/db/connection.py
+++ b/conceptnet5/db/connection.py
@@ -30,33 +30,22 @@ def get_db_connection(dbname=None, building=False):
             except pg8000.InterfaceError:
                 if attempt == 0:
                     print(
-                        "Database %r at %s:%s is not available, retrying for 10 seconds"
-                        % (dbname, config.DB_HOSTNAME, config.DB_PORT),
+                        "Database %r is not available, retrying for 10 seconds" % dbname,
                         file=sys.stderr
                     )
                 time.sleep(1)
         raise IOError(
-            "Couldn't connect to database %r at %s:%s" %
-            (dbname, config.DB_HOSTNAME, config.DB_PORT)
+            "Couldn't connect to database %r" % dbname
         )
 
 
 def _get_db_connection_inner(dbname):
-    if not config.DB_PASSWORD:
-        conn = pg8000.connect(
-            user=config.DB_USERNAME,
-            unix_sock=config.DB_SOCKET,
-            database=dbname
-        )
-    else:
-        conn = pg8000.connect(
-            user=config.DB_USERNAME,
-            password=config.DB_PASSWORD,
-            host=config.DB_HOSTNAME,
-            port=config.DB_PORT,
-            database=dbname
-        )
-
+    conn = pg8000.connect(
+        user=config.DB_USERNAME,
+        password=config.DB_PASSWORD or None,
+        unix_sock=config.DB_SOCKET,
+        database=dbname
+    )
     pg8000.paramstyle = 'named'
     return conn
 


### PR DESCRIPTION
This change makes ConceptNet default to connecting to PostgreSQL via a "local socket", a file-like object in `/var/run`.

I think this is more efficient than connecting over a network port, but the primary advantage is that this kind of connection can be handled differently by PostgreSQL, including not requiring a password.

As I try to get rid of Docker, this makes a good substitute for the fact that I managed to configure the PostgreSQL within Docker to never require passwords. (It'll still use a password if you supply one in the appropriate environment variable, so this shouldn't break things for people who set up a password and stuff to run ConceptNet outside of Docker.)
