### PR TITLE
Update input from fastText and Nadya

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -31,9 +31,9 @@ N_PIECES = 16
 # The versions of Wiktionary data to download. Updating these requires
 # uploading new Wiktionary dumps to ConceptNet's S3.
 WIKTIONARY_VERSIONS = {
-    'en': '20160305',
-    'fr': '20160305',
-    'de': '20160407'
+    'en': '20171201',
+    'fr': '20171201',
+    'de': '20171201'
 }
 WIKTIONARY_LANGUAGES = sorted(list(WIKTIONARY_VERSIONS))
 
@@ -52,7 +52,7 @@ EMOJI_LANGUAGES = [
 ]
 
 # Increment this number when we incompatibly change the parser
-WIKT_PARSER_VERSION = "1"
+WIKT_PARSER_VERSION = "2"
 
 RETROFIT_SHARDS = 6
 

--- a/Snakefile
+++ b/Snakefile
@@ -62,7 +62,7 @@ PRECOMPUTED_DATA_URL = "https://conceptnet.s3.amazonaws.com" + PRECOMPUTED_DATA_
 PRECOMPUTED_S3_UPLOAD = "s3://conceptnet" + PRECOMPUTED_DATA_PATH
 
 INPUT_EMBEDDINGS = [
-    'glove12-840B', 'w2v-google-news', 'fasttext-opensubtitles'
+    'crawl-300d-2M', 'w2v-google-news', 'glove12-840B', 'fasttext-opensubtitles'
 ]
 SOURCE_EMBEDDING_ROWS = 1500000
 MULTILINGUAL_SOURCE_EMBEDDING_ROWS = 2000000
@@ -571,6 +571,16 @@ rule convert_glove:
         ram=24
     shell:
         "CONCEPTNET_DATA=data cn5-vectors convert_glove -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
+
+rule convert_fasttext_crawl:
+    input:
+        DATA + "/raw/vectors/crawl-300d-2M.vec.gz"
+    output:
+        DATA + "/vectors/crawl-300d-2M.h5"
+    resources:
+        ram=24
+    shell:
+        "CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {input} {output}"
 
 rule convert_fasttext:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -32,8 +32,8 @@ N_PIECES = 16
 # uploading new Wiktionary dumps to ConceptNet's S3.
 WIKTIONARY_VERSIONS = {
     'en': '20171201',
-    'fr': '20171201',
-    'de': '20171201'
+    'fr': '20160305',
+    'de': '20160407'
 }
 WIKTIONARY_LANGUAGES = sorted(list(WIKTIONARY_VERSIONS))
 
@@ -150,7 +150,7 @@ rule webdata:
 
 rule clean:
     shell:
-        "for subdir in assertions assoc collated db edges psql tmp vectors stats; "
+        "for subdir in assertions assoc collated db edges morph psql tmp vectors stats; "
         "do echo Removing %(data)s/$subdir; "
         "rm -rf %(data)s/$subdir; done" % {'data': DATA}
 

--- a/Snakefile
+++ b/Snakefile
@@ -265,7 +265,7 @@ rule read_jmdict:
 
 rule read_nadya:
     input:
-        DATA + "/raw/nadya/nadya-2014.csv"
+        DATA + "/raw/nadya/nadya-2017.csv"
     output:
         DATA + "/edges/nadya/nadya.msgpack"
     shell:

--- a/conceptnet5/readers/conceptnet4.py
+++ b/conceptnet5/readers/conceptnet4.py
@@ -319,6 +319,9 @@ def build_sources(parts_dict, preposition_fix=False):
 
 # TODO: this doesn't need to be a class
 class CN4Builder(object):
+    def __init__(self, weight=1.):
+        self.weight = weight
+
     def handle_assertion(self, parts_dict):
         """
         Process one assertion from ConceptNet 4, which appears in the input
@@ -374,7 +377,7 @@ class CN4Builder(object):
                     rel=relation, start=start, end=end,
                     dataset=dataset, license=Licenses.cc_attribution,
                     sources=[source_dict], surfaceText=frame_text,
-                    weight=weight
+                    weight=weight * self.weight
                 )
 
     def transform_file(self, input_filename, output_file):

--- a/conceptnet5/readers/conceptnet4.py
+++ b/conceptnet5/readers/conceptnet4.py
@@ -317,9 +317,17 @@ def build_sources(parts_dict, preposition_fix=False):
     return sources
 
 
-# TODO: this doesn't need to be a class
 class CN4Builder(object):
     def __init__(self, weight=1.):
+        """
+        Create a builder for processing a source of ConceptNet-4-style
+        assertions.
+
+        The optional parameter provides a weight multiplier, which will modify
+        the weight computed by `build_sources`. For example, this can be set
+        lower than 1 for GWAPs, where we don't necessarily trust that every edge
+        is a real assertion about common sense.
+        """
         self.weight = weight
 
     def handle_assertion(self, parts_dict):
@@ -377,6 +385,9 @@ class CN4Builder(object):
                     rel=relation, start=start, end=end,
                     dataset=dataset, license=Licenses.cc_attribution,
                     sources=[source_dict], surfaceText=frame_text,
+
+                    # The edge weight is the weight computed by build_sources,
+                    # times the multiplier set on this instance
                     weight=weight * self.weight
                 )
 

--- a/conceptnet5/readers/nadya.py
+++ b/conceptnet5/readers/nadya.py
@@ -6,44 +6,46 @@ from conceptnet5.readers.conceptnet4 import CN4Builder
 from conceptnet5.formats.msgpack_stream import MsgpackStreamWriter
 
 # The nadya.jp data is distributed as a PostgreSQL database. The following
-# command will extract a file in the form of 'nadya-2014.csv' from such a
+# command will extract a file in the form of 'nadya-2017.csv' from such a
 # database:
 #
-#    SELECT
-#        ra.id as cnet4_id,
-#        ra.language_id as lang,
-#        f.text as frame_text,
-#        r.name as relname,
-#        s1.text as start_text,
-#        s2.text as end_text,
-#        fr.value as freq,
-#        v.vote,
-#        u.username as creator,
-#        u2.username as voter
-#    FROM
-#        conceptnet_rawassertion ra,
-#        conceptnet_frame f,
-#        conceptnet_assertion a,
-#        auth_user u,
-#        auth_user u2,
-#        nl_frequency fr,
-#        conceptnet_surfaceform s1,
-#        conceptnet_surfaceform s2,
-#        conceptnet_relation r,
-#        votes v
-#    WHERE
-#        ra.frame_id=f.id and
-#        ra.assertion_id=a.id and
-#        ra.creator_id=u.id and
-#        f.frequency_id = fr.id and
-#        ra.surface1_id=s1.id and
-#        ra.surface2_id=s2.id and
-#        a.relation_id=r.id and
-#        v.object_id=a.id and
-#        v.user_id=u2.id and
-#        u.email='a@nadya.jp' and
-#        v.vote > 0 and
-#        u.username != 'root';
+# SELECT
+#     ra.id as cnet4_id,
+#     ra.language_id as lang,
+#     f.text as frame_text,
+#     r.name as relname,
+#     s1.text as start_text,
+#     s2.text as end_text,
+#     fr.value as freq,
+#     v.vote,
+#     u.email,
+#     u.username as creator,
+#     u2.username as voter
+# FROM
+#     conceptnet_rawassertion ra,
+#     conceptnet_frame f,
+#     conceptnet_assertion a,
+#     auth_user u,
+#     auth_user u2,
+#     nl_frequency fr,
+#     conceptnet_surfaceform s1,
+#     conceptnet_surfaceform s2,
+#     conceptnet_relation r,
+#     votes v
+# WHERE
+#     ra.frame_id=f.id and
+#     ra.assertion_id=a.id and
+#     ra.creator_id=u.id and
+#     f.frequency_id = fr.id and
+#     a.best_surface1_id=s1.id and
+#     a.best_surface2_id=s2.id and
+#     a.relation_id=r.id and
+#     a.score > 1 and
+#     v.object_id=a.id and
+#     v.user_id=u2.id and
+#     v.vote > 0 and
+#     u.username like 'nadya%'
+# ;
 
 
 def handle_line(line, builder):
@@ -53,7 +55,7 @@ def handle_line(line, builder):
     """
     parts = line.rstrip('\n').split('\t')
     (cnet4_id, lang, frame_text, relname, start_text, end_text,
-     freq, vote, creator, voter) = parts
+     freq, vote, email, creator, voter) = parts
     if cnet4_id == 'cnet4_id':
         return
 
@@ -94,4 +96,3 @@ def handle_file(input_filename, output_file):
         # Get a line from the file
         for new_obj in handle_line(line, builder):
             out.write(new_obj)
-

--- a/conceptnet5/readers/nadya.py
+++ b/conceptnet5/readers/nadya.py
@@ -64,29 +64,30 @@ def handle_line(line, builder):
     freq = int(freq)
     vote = int(vote)
 
-    # Create the parts_dict that CN4Builder expects
-    parts_dict = {
-        'lang': lang,
-        'polarity': freq,
-        'cnet4_id': cnet4_id,
-        'relname': relname,
-        'frame_text': frame_text,
-        'startText': start_text,
-        'endText': end_text,
-        # In the case of nadya.jp, it's not important to track the creator
-        # separately from the voters -- they were all doing the same
-        # thing.
-        #
-        # Each voter just shows up as the source of a separate
-        # edge, which is what the CN4Builder ultimately does with the
-        # votes anyway. The only reason the CN4Builder takes more complex
-        # input is to handle weird edge cases.
-        'creator': voter,
-        'votes': [],
-        'activity': 'nadya.jp',
-        'goodness': 3
-    }
-    yield from builder.handle_assertion(parts_dict)
+    if vote > 0:
+        # Create the parts_dict that CN4Builder expects
+        parts_dict = {
+            'lang': lang,
+            'polarity': freq,
+            'cnet4_id': cnet4_id,
+            'relname': relname,
+            'frame_text': frame_text,
+            'startText': start_text,
+            'endText': end_text,
+            # In the case of nadya.jp, it's not important to track the creator
+            # separately from the voters -- they were all doing the same
+            # thing.
+            #
+            # Each voter just shows up as the source of a separate
+            # edge, which is what the CN4Builder ultimately does with the
+            # votes anyway. The only reason the CN4Builder takes more complex
+            # input is to handle weird edge cases.
+            'creator': voter,
+            'votes': [],
+            'activity': 'nadya.jp',
+            'goodness': 3
+        }
+        yield from builder.handle_assertion(parts_dict)
 
 
 def handle_file(input_filename, output_file):

--- a/conceptnet5/readers/nadya.py
+++ b/conceptnet5/readers/nadya.py
@@ -90,7 +90,7 @@ def handle_line(line, builder):
 
 
 def handle_file(input_filename, output_file):
-    builder = CN4Builder()
+    builder = CN4Builder(weight=0.1)
     out = MsgpackStreamWriter(output_file)
     for line in open(input_filename, encoding='utf-8'):
         # Get a line from the file

--- a/conceptnet5/readers/wiktionary.py
+++ b/conceptnet5/readers/wiktionary.py
@@ -143,6 +143,13 @@ def transform_relation(rel):
 
 def transform_term(data_language, termdata, assumed_languages, db, use_etyms=True):
     text = termdata['text']
+
+    # Sometimes - is used to fill a slot in a Wiktionary template where the
+    # term would usually be. It typically means "don't show this part", with
+    # the implication "the term in question is obvious from context".
+    #
+    # Context is hard, so let's just cope with a hyphen as the term by
+    # discarding it.
     if text == '-':
         return None
     language = termdata.get('language')

--- a/conceptnet5/readers/wiktionary.py
+++ b/conceptnet5/readers/wiktionary.py
@@ -143,6 +143,8 @@ def transform_relation(rel):
 
 def transform_term(data_language, termdata, assumed_languages, db, use_etyms=True):
     text = termdata['text']
+    if text == '-':
+        return None
     language = termdata.get('language')
     if language is None:
         language = disambiguate_language(text, assumed_languages, db)


### PR DESCRIPTION
This PR contains two new data updates, on top of the Wiktionary update that's in #151:

- It uses fastText's new vectors that are precomputed on the Common Crawl as an additional vector-space input, similar to the precomputed word2vec and GloVe inputs.
- It adds new data that Nihon Unisys sent from nadya.jp. The data is messier but more plentiful. Adding it with a low weight keeps the Japanese word-relatedness accuracy about the same while expanding its vocabulary.

#151 should be merged first.

The thing that these two changes have in common is that they will require an update to the raw data package, which I'd like to publish to Zenodo around when this PR is likely to be accepted, so let me know.