### PR TITLE
Fix broken code, outdated docs, lemma problem in convert.py

### DIFF
--- a/conceptnet5/edges.py
+++ b/conceptnet5/edges.py
@@ -5,7 +5,7 @@ an edge.
 """
 
 from conceptnet5.uri import (
-    assertion_uri, uri_prefix, conjunction_uri, is_concept, split_uri
+    assertion_uri, uri_prefix, conjunction_uri, is_concept
 )
 from conceptnet5.nodes import ld_node
 import re


### PR DESCRIPTION
Plus a flake8 fix to edges.py that I noticed at the same time.

Clearly we haven't been using msgpack_to_json and json_to_msgpack,
perhaps because the current CSV format includes all the same data in a
fairly useful form. But it seemed worth it to fix the converters.

The change that actually affects the ConceptNet graph is that the
"msgpack_to_assoc" step was converting "A person wants X" to "X is
good", but failing to convert "People want X" ever since we stopped
auto-lemmatizing things. This should have an effect on sentiment
generated from ConceptNet, and hopefully a positive effect.