### PR TITLE
Replace .loc[] with .reindex() when keys might be missing

### DIFF
--- a/conceptnet5/vectors/debias.py
+++ b/conceptnet5/vectors/debias.py
@@ -394,10 +394,9 @@ def reject_subspace(frame, vecs):
     """
     current_array = frame.copy().values
     for vec in vecs:
-        if not np.isnan(vec).any():
-            vec = normalize_vec(vec)
-            projection = current_array.dot(vec)
-            np.subtract(current_array, np.outer(projection, vec), out=current_array)
+        vec = normalize_vec(vec)
+        projection = current_array.dot(vec)
+        np.subtract(current_array, np.outer(projection, vec), out=current_array)
 
     normalize(current_array, norm='l2', copy=False)
 
@@ -412,7 +411,7 @@ def get_vocabulary_vectors(frame, vocab):
     given DataFrame containing just the known vectors for that vocabulary.
     """
     uris = [standardized_uri('en', term) for term in vocab]
-    return frame.loc[uris].dropna()
+    return frame.reindex(uris).dropna()
 
 
 def two_class_svm(frame, pos_vocab, neg_vocab):
@@ -528,7 +527,7 @@ def de_bias_category(frame, category_examples, bias_examples):
     vocab = [
         standardized_uri('en', term) for term in bias_examples
     ]
-    components_to_reject = frame.loc[vocab].values
+    components_to_reject = frame.reindex(vocab).dropna().values
 
     # Make a modified version of the space that projects the bias vectors to 0.
     # Then weight each row of that space by "applicability", the probability

--- a/conceptnet5/vectors/transforms.py
+++ b/conceptnet5/vectors/transforms.py
@@ -117,7 +117,7 @@ def make_replacements_faster(small_frame, big_frame, tree_depth=1000, lang='en',
 
     tree_depth=1000 provides a good balance of speed and accuracy.
     """
-    intersected = big_frame.loc[small_frame.index].dropna()
+    intersected = big_frame.reindex(small_frame.index).dropna()
     index, index_map = build_annoy_tree(intersected, tree_depth)
     replacements = {}
     for term in big_frame.index:
@@ -138,7 +138,7 @@ def make_replacements(small_frame, big_frame):
     Create a replacements dictionary to map terms only present in a big frame to the closest term
     in a small_frame. This method uses a brute-force solution.
     """
-    intersected = big_frame.loc[small_frame.index].dropna()
+    intersected = big_frame.reindex(small_frame.index).dropna()
     replacements = {}
     for term in big_frame.index:
         if term not in small_frame.index:


### PR DESCRIPTION
There are many instances of .loc[] with a list that I have left as-is;
those are the ones where I think we *should* get an error if keys are
missing. But in the cases where we're just going to drop the missing
rows with .dropna(), we should be using .reindex().