### PR TITLE
Fixes for code review 20180517.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -651,13 +651,13 @@ rule join_retrofit:
     resources:
         ram=24
     shell:
-        "cn5-vectors join_retrofit -s {RETROFIT_SHARDS} {output}"
+        "cn5-vectors join_shard_files -s {RETROFIT_SHARDS} {output}"
 
 rule merge_intersect:
     input:
         expand(DATA + "/vectors/{name}-retrofit.h5", name=INPUT_EMBEDDINGS)
     output:
-        DATA + "/vectors/numberbatch-biased.h5",
+        DATA + "/vectors/numberbatch-retrofitted.h5",
         DATA + "/vectors/intersection-projection.h5"
     resources:
         ram=24
@@ -667,27 +667,27 @@ rule merge_intersect:
 rule propagate:
     input:
         DATA + "/assoc/assoc.csv",
-        DATA + "/vectors/numberbatch-biased.h5"
+        DATA + "/vectors/numberbatch-retrofitted.h5"
     output:
-        temp(expand(DATA + "/vectors/numberbatch-propagated.h5.shard{n}", n=range(PROPAGATE_SHARDS)))
+        temp(expand(DATA + "/vectors/numberbatch-biased.h5.shard{n}", n=range(PROPAGATE_SHARDS)))
     resources:
         ram=24
     shell:
-        "cn5-vectors propagate -s {PROPAGATE_SHARDS} {input} {DATA}/vectors/numberbatch-propagated.h5"
+        "cn5-vectors propagate -s {PROPAGATE_SHARDS} {input} {DATA}/vectors/numberbatch-biased.h5"
 
 rule join_propagate:
     input:
-        expand(DATA + "/vectors/numberbatch-propagated.h5.shard{n}", n=range(PROPAGATE_SHARDS))
+        expand(DATA + "/vectors/numberbatch-biased.h5.shard{n}", n=range(PROPAGATE_SHARDS))
     output:
-        DATA + "/vectors/numberbatch-propagated.h5"
+        DATA + "/vectors/numberbatch-biased.h5"
     resources:
         ram=24
     shell:
-        "cn5-vectors join_propagate -s {PROPAGATE_SHARDS} --sort {output}"
+        "cn5-vectors join_shard_files -s {PROPAGATE_SHARDS} --sort {output}"
 
 rule debias:
     input:
-        DATA + "/vectors/numberbatch-propagated.h5"
+        DATA + "/vectors/numberbatch-biased.h5"
     output:
         DATA + "/vectors/numberbatch.h5"
     resources:
@@ -697,7 +697,7 @@ rule debias:
 
 rule miniaturize:
     input:
-        DATA + "/vectors/numberbatch-propagated.h5",
+        DATA + "/vectors/numberbatch-biased.h5",
         DATA + "/vectors/w2v-google-news.h5"
     output:
         DATA + "/vectors/mini.h5"
@@ -764,7 +764,7 @@ rule compare_embeddings:
         DATA + "/raw/vectors/glove12.840B.300d.txt.gz",
         DATA + "/vectors/glove12-840B.h5",
         DATA + "/raw/vectors/fasttext-wiki-en.vec.gz",
-        DATA + "/vectors/numberbatch-propagated.h5",
+        DATA + "/vectors/numberbatch-biased.h5",
         DATA + "/vectors/numberbatch.h5",
         DATA + "/raw/analogy/SAT-package-V3.txt",
         DATA + "/psql/done"

--- a/Snakefile
+++ b/Snakefile
@@ -641,7 +641,7 @@ rule retrofit:
     resources:
         ram=24
     shell:
-        "cn5-vectors retrofit -s {RETROFIT_SHARDS} {input} {DATA}/vectors/{wildcards.name}-retrofit.h5"
+        "cn5-vectors retrofit -n {RETROFIT_SHARDS} {input} {DATA}/vectors/{wildcards.name}-retrofit.h5"
 
 rule join_retrofit:
     input:
@@ -651,7 +651,7 @@ rule join_retrofit:
     resources:
         ram=24
     shell:
-        "cn5-vectors join_shard_files -s {RETROFIT_SHARDS} {output}"
+        "cn5-vectors join_shard_files -n {RETROFIT_SHARDS} {output}"
 
 rule merge_intersect:
     input:
@@ -673,7 +673,7 @@ rule propagate:
     resources:
         ram=24
     shell:
-        "cn5-vectors propagate -s {PROPAGATE_SHARDS} {input} {DATA}/vectors/numberbatch-biased.h5"
+        "cn5-vectors propagate -n {PROPAGATE_SHARDS} {input} {DATA}/vectors/numberbatch-biased.h5"
 
 rule join_propagate:
     input:
@@ -683,7 +683,7 @@ rule join_propagate:
     resources:
         ram=24
     shell:
-        "cn5-vectors join_shard_files -s {PROPAGATE_SHARDS} --sort {output}"
+        "cn5-vectors join_shard_files -n {PROPAGATE_SHARDS} --sort {output}"
 
 rule debias:
     input:

--- a/conceptnet5/builders/cli.py
+++ b/conceptnet5/builders/cli.py
@@ -24,16 +24,17 @@ def run_combine(input, output):
 
 
 @cli.command(name='reduce_assoc')
-@click.argument('input_filenames', nargs=-1, type=click.Path(readable=True, dir_okay=False))
+@click.argument('assoc_filename', type=click.Path(readable=True, dir_okay=False))
+@click.argument('embedding_filenames', nargs=-1, type=click.Path(readable=True, dir_okay=False))
 @click.argument('output', type=click.Path(writable=True, dir_okay=False))
-def run_reduce_assoc(input_filenames, output):
+def run_reduce_assoc(assoc_filename, embedding_filenames, output):
     """
     Takes in a file of tab-separated simple associations, one or more 
     hdf5 files defining vector embeddings, and removes from the associations 
     low-frequency terms and associations that are judged unlikely to be
     useful by various filters.
     """
-    reduce_assoc(input_filenames[0], input_filenames[1:], output)
+    reduce_assoc(assoc_filename, embedding_filenames, output)
 
 
 @cli.command('prepare_morphology')

--- a/conceptnet5/builders/reduce_assoc.py
+++ b/conceptnet5/builders/reduce_assoc.py
@@ -26,24 +26,19 @@ def concept_is_bad(uri):
 class ConceptNetAssociationGraph:
     '''
     Class to hold the concept-association edge graph.
+    
+    Note that this class currently has two use cases (reduced 
+    association graphs and full graphs used for propagation of vector 
+    embeddings), and the edge data needed in each case is different.  
+    So that data is not stored in the graph, but is returned along 
+    with the graph by the factory function make_conceptnet_association_graph.
     '''
-    def __init__(self, save_edge_list=True):
+    def __init__(self):
         '''Construct a graph with no vertices or edges.'''
-        if save_edge_list:
-            self._edge_list = list()
-            self._edge_set = None
-        else:
-            self._edge_list = None
-            self._edge_set = set()
         self.vertex_to_neighbors = defaultdict(set)
-        return
 
-    def add_edge(self, left, right, value, dataset, rel):
+    def add_edge(self, left, right, value, dataset, relation):
         '''Insert an edge in the graph.'''
-        if self._edge_list is not None:
-            self._edge_list.append((left, right, value, dataset, rel))
-        else:
-            self._edge_set.add((left, right))
         self.vertex_to_neighbors[left].add(right)
         self.vertex_to_neighbors[right].add(left)
         return
@@ -51,25 +46,6 @@ class ConceptNetAssociationGraph:
     def vertices(self):
         '''Returns an iterator over the vertices of the graph.'''
         return self.vertex_to_neighbors.keys()
-
-    def edge_list(self):
-        '''
-        Returns an iterator over the edges (left, right, value, dataset, erl) 
-        of the graph.  Can only be used if the graph was constructed with 
-        save_edge_list=True.
-        '''
-        for edge in self._edge_list:
-            yield edge
-        return
-
-    def edge_set(self):
-        '''
-        Returns an iterator over the edges (left, right) of the graph.  
-        Can only be used if the graph was constructed with save_edge_list=False.
-        '''
-        for edge in self._edge_set:
-            yield edge
-        return
 
     def find_components(self):
         '''
@@ -100,6 +76,25 @@ class ConceptNetAssociationGraph:
                         stack.append(neighbor)
 
         return component_labels
+
+
+class ConceptNetAssociationGraphForReduction(ConceptNetAssociationGraph):
+    """
+    Subclass of ConceptNetAssociationGraph specialized for use in making 
+    the reduced subgraph of a full set of associations.
+    """
+    def __init__(self):
+        super().__init__()
+        self.edges = []
+    
+    def add_edge(self, left, right, value, dataset, relation):
+        """
+        In addition to the superclass's handling of a new edge, 
+        saves the full edge data.
+        """
+        super().add_edge(left, right, value, dataset, relation)
+        self.edges.append((left, right, value, dataset, relation))
+
 
 
 def make_filtered_concepts(filename, cutoff=3, en_cutoff=3):
@@ -136,35 +131,66 @@ def make_filtered_concepts(filename, cutoff=3, en_cutoff=3):
 
 
 def make_conceptnet_association_graph(
-        filename, save_edge_list=True,
-        concept_filter=None, bad_concept=concept_is_bad,
-        bad_relation=is_negative_relation):
+        filename,
+        graph_class=ConceptNetAssociationGraph,
+        filtered_concepts=None,
+        reject_negative_relations=True):
     """
-    Reads an association file and builds an (undirected) graph from it, 
-    """
-    graph = ConceptNetAssociationGraph(save_edge_list)
-    if concept_filter is None:
-        concept_filter = lambda concept: True
-    if bad_concept is None:
-        bad_concept = lambda concept: False
-    if bad_relation is None:
-        bad_relation = lambda rel: False
+    Reads an association file and builds an (undirected) graph from it. 
     
+    Returns a pair: the graph, and associated edge data.
+    
+    The optional graph_class parameter should be a subclass of 
+    ConceptNetAssociationGraph (which is the default value); an instance 
+    of this class will be returned.
+    
+    If filtered_concepts is not None, it should be a collection of concepts, 
+    and only vertices from this collection and edges that link two such 
+    vertices will be added to the graph.  If it _is_ None (the default), 
+    however, please note that no such filtering will be done (i.e. the 
+    effective filter collection is then the universal set of concepts, not 
+    the empty set).
+    
+    If reject_negative_relations is True (the default), only edges not 
+    corresponding to negative relations will be added to the graph.
+    """
+    graph = graph_class()
+    
+    if filtered_concepts is None:
+        filter_concepts = False
+    else:
+        filter_concepts = True
+        
     with open(filename, encoding='utf-8') as file:
         for line in file:
             left, right, value, dataset, rel = line.rstrip().split('\t', 4)
-            if bad_concept(left) or bad_concept(right) or bad_relation(rel):
+            if concept_is_bad(left) or concept_is_bad(right):
+                continue
+            if reject_negative_relations and is_negative_relation(rel):
                 continue
             fvalue = float(value)
             gleft = uri_prefix(left)
             gright = uri_prefix(right)
-            if concept_filter(gleft) and concept_filter(gright) \
-               and fvalue != 0 and gleft != gright:
-                graph.add_edge(gleft, gright, value, dataset, rel)
+            if fvalue == 0:
+                continue
+            if gleft == gright:
+                continue
+            if filter_concepts and gleft not in filtered_concepts:
+                continue
+            if filter_concepts and gright not in filtered_concepts:
+                continue
+            graph.add_edge(gleft, gright, value, dataset, rel)
+                
     return graph
 
 
 def read_embedding_vocabularies(filenames):
+    """
+    Reads every vector embedding file in the given collection of 
+    filenames, and returns the union of their vocabularies.  (The 
+    files are assumed to be hdf5 files containing dataframes, and 
+    the vocabularies are their indices.
+    """
     result = pd.Index([])
     for filename in filenames:
         vectors = load_hdf(filename)
@@ -192,21 +218,26 @@ def reduce_assoc(assoc_filename, embedding_filenames, output_filename,
 
     graph = make_conceptnet_association_graph(
         assoc_filename,
-        concept_filter=lambda concept:
-        concept in filtered_concepts,
-        bad_concept=concept_is_bad,
-        bad_relation=is_negative_relation)
+        graph_class=ConceptNetAssociationGraphForReduction, 
+        filtered_concepts=filtered_concepts,
+        reject_negative_relations=True
+    )
 
     component_labels = graph.find_components()
 
     embedding_vocab = read_embedding_vocabularies(embedding_filenames)
 
+    # If a connected component of the conceptnet graph contains no terms
+    # from any of the embedding vocabularies, there will be no way to assign
+    # vectors to any of its vertices, so we remove that component from the
+    # output.
+    
     good_component_labels = set(label for term, label
                                 in component_labels.items()
                                 if term in embedding_vocab)
     
     with open(output_filename, 'w', encoding='utf-8') as out:
-        for gleft, gright, value, dataset, rel in graph.edge_list():
+        for gleft, gright, value, dataset, rel in graph.edges:
             if component_labels[gleft] not in good_component_labels:
                 continue
             if component_labels[gright] not in good_component_labels:

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -63,16 +63,6 @@ def run_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
     )
 
 
-@cli.command(name='join_retrofit')
-@click.argument('filename', type=click.Path(writable=True, dir_okay=False))
-@click.option('--nshards', '-s', default=6)
-def run_join_retrofit(filename, nshards=6):
-    """
-    Join parts of a retrofitted frame.
-    """
-    join_shards(filename, nshards)
-
-
 @cli.command(name='convert_glove')
 @click.argument('glove_filename', type=click.Path(readable=True, dir_okay=False))
 @click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
@@ -300,12 +290,12 @@ def run_propagate(assoc_filename, embedding_filename, output_filename,
                       nshards=nshards, iterations=iterations)
 
 
-@cli.command(name='join_propagate')
+@cli.command(name='join_shard_files')
 @click.argument('filename', type=click.Path(writable=True, dir_okay=False))
 @click.option('--nshards', '-s', default=6)
 @click.option('--sort/--no-sort', default=True)
-def run_join_propagate(filename, nshards=6, sort=True):
+def run_join_shard_files(filename, nshards=6, sort=True):
     """
-    Join parts of a propagated frame.
+    Join parts of a sharded (e.g. from retrofitting or propagation) frame.
     """
     join_shards(filename, nshards, sort=sort)

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -48,7 +48,7 @@ def filter_word_vectors(dense_hdf_filename, vocab_filename):
 @click.argument('conceptnet_filename', type=click.Path(readable=True, dir_okay=False))
 @click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
 @click.option('--iterations', '-i', default=5)
-@click.option('--nshards', '-s', default=6)
+@click.option('--nshards', '-n', default=6)
 @click.option('--verbose', '-v', count=True)
 @click.option('--max_cleanup_iters', '-m', default=20)
 def run_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
@@ -282,7 +282,7 @@ def export_background(input_filename, output_dir, concepts_filename, language):
                 type=click.Path(readable=True, dir_okay=False))
 @click.argument('output_filename',
                 type=click.Path(writable=True, dir_okay=False))
-@click.option('--nshards', '-s', default=6)
+@click.option('--nshards', '-n', default=6)
 @click.option('--iterations', default=20)
 def run_propagate(assoc_filename, embedding_filename, output_filename,
                   nshards=6, iterations=20):
@@ -292,9 +292,9 @@ def run_propagate(assoc_filename, embedding_filename, output_filename,
 
 @cli.command(name='join_shard_files')
 @click.argument('filename', type=click.Path(writable=True, dir_okay=False))
-@click.option('--nshards', '-s', default=6)
-@click.option('--sort/--no-sort', default=True)
-def run_join_shard_files(filename, nshards=6, sort=True):
+@click.option('--nshards', '-n', default=6)
+@click.option('--sort/--no-sort', default=False)
+def run_join_shard_files(filename, nshards=6, sort=False):
     """
     Join parts of a sharded (e.g. from retrofitting or propagation) frame.
     """

--- a/conceptnet5/vectors/propagate.py
+++ b/conceptnet5/vectors/propagate.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import diags
 from conceptnet5.builders.reduce_assoc import ConceptNetAssociationGraph
-from conceptnet5.builders.reduce_assoc import make_conceptnet_association_graph
 from conceptnet5.uri import get_uri_language
 from .sparse_matrix_builder import SparseMatrixBuilder
 from .formats import load_hdf, save_hdf
@@ -90,10 +89,8 @@ def make_adjacency_matrix(assoc_filename, embedding_vocab):
     # overlap the vocabulary of the embedding; we can't do anything with
     # those terms.
 
-    graph = make_conceptnet_association_graph(
-        assoc_filename,
-        graph_class=ConceptNetAssociationGraphForPropagation,
-        reject_negative_relations=False)
+    graph = ConceptNetAssociationGraphForPropagation.from_csv(
+        assoc_filename, reject_negative_relations=False)
     component_labels = graph.find_components()
 
     # Get the labels of components that overlap the embedding vocabulary.

--- a/conceptnet5/vectors/propagate.py
+++ b/conceptnet5/vectors/propagate.py
@@ -7,10 +7,31 @@ reduced graph.
 import numpy as np
 import pandas as pd
 from scipy.sparse import diags
+from conceptnet5.builders.reduce_assoc import ConceptNetAssociationGraph
 from conceptnet5.builders.reduce_assoc import make_conceptnet_association_graph
 from conceptnet5.uri import get_uri_language
 from .sparse_matrix_builder import SparseMatrixBuilder
 from .formats import load_hdf, save_hdf
+
+
+class ConceptNetAssociationGraphForPropagation(ConceptNetAssociationGraph):
+    """
+    Subclass of ConceptNetAssociationGraph specialized for use in making 
+    the full graph of a set of associations as required for propagation.
+    """
+    def __init__(self):
+        super().__init__()
+        self.edges = set()
+
+    def add_edge(self, left, right, value, dataset, relation):
+        """
+        In addition to the superclass's handling of a new edge, 
+        saves the edges as a set of (left, right) pairs.  Note that 
+        we do not save (right, left) as well as (left, right) (but also 
+        do not guarantee that only one of the two has been saved).
+        """
+        super().add_edge(left, right, value, dataset, relation)
+        self.edges.add((left, right))
 
 
 def sharded_propagate(assoc_filename, embedding_filename, 
@@ -20,6 +41,10 @@ def sharded_propagate(assoc_filename, embedding_filename,
     splitting the embedding into shards (along the dimensions of the 
     embedding feature space).
     """
+    # frame_box is basically a reference to a single large DataFrame. The
+    # DataFrame will at times be present or absent. When it's present, the list
+    # contains one item, which is the DataFrame. When it's absent, the list
+    # is empty.
     frame_box = [load_hdf(embedding_filename)]
     adjacency_matrix, combined_index, n_new_english = \
         make_adjacency_matrix(assoc_filename, frame_box[0].index)
@@ -34,6 +59,8 @@ def sharded_propagate(assoc_filename, embedding_filename,
         embedding_shard = pd.DataFrame(
             frame_box[0].iloc[:, shard_from:shard_to])
 
+        # Delete full_dense_frame while running retrofitting, because it takes
+        # up a lot of memory and we can reload it from disk later.
         frame_box.clear()
 
         propagated = propagate(combined_index, embedding_shard,
@@ -64,17 +91,26 @@ def make_adjacency_matrix(assoc_filename, embedding_vocab):
     # those terms.
 
     graph = make_conceptnet_association_graph(
-        assoc_filename, save_edge_list=False,
-        bad_concept=None, bad_relation=None)
+        assoc_filename,
+        graph_class=ConceptNetAssociationGraphForPropagation,
+        reject_negative_relations=False)
     component_labels = graph.find_components()
+
+    # Get the labels of components that overlap the embedding vocabulary.
     good_component_labels = set(label for term, label
                                 in component_labels.items()
                                 if term in embedding_vocab)
+
+    # Now get the concepts in those components.
     good_concepts = set(term for term, label
                         in component_labels.items()
                         if label in good_component_labels)
+    
     del component_labels, good_component_labels
 
+    # Put terms from the embedding first, then terms from the good part
+    # of the graph neither from the embedding nor in English, then terms
+    # from the good part of the graph in English but not from the embedding.
     new_vocab = good_concepts - set(embedding_vocab)
     good_concepts = embedding_vocab.append(
         pd.Index(term for term in new_vocab
@@ -99,7 +135,7 @@ def make_adjacency_matrix(assoc_filename, embedding_vocab):
     # we may want to add such edges here as well.
     
     builder = SparseMatrixBuilder()
-    for v,w in graph.edge_set():
+    for v,w in graph.edges:
         try:
             index0 = good_concepts_map[v]
             index1 = good_concepts_map[w]
@@ -141,12 +177,14 @@ def propagate(combined_index, embedding, adjacency_matrix, n_new_english,
         nonzero_indices = np.logical_not(zero_indices)
         fringe = (adjacency_matrix.dot(nonzero_indices.astype(np.int8)) != 0)
         fringe = np.logical_and(fringe, zero_indices)
-        # Then pick a neighbor for each, and use it to update the zero vector.
-        adjacent_nonzeros = adjacency_matrix.dot(
+        # Update each as the average of its nonzero neighbors
+        adjacent_nonzeros = adjacency_matrix[fringe, :].dot(
             diags([nonzero_indices.astype(np.int8)], [0], format='csc'))
-        neighbors = np.argmax(adjacent_nonzeros[fringe, :], axis=1)
-        neighbors = neighbors.A[:, 0] # convert matrix to 1D ndarray
-        vectors[fringe, :] = vectors[neighbors, :]
+        n_adjacent_nonzeros = adjacent_nonzeros.sum(axis=1).A[:, 0]
+        weights = 1.0 / n_adjacent_nonzeros
+        vectors[fringe, :] = adjacency_matrix[fringe, :].dot(vectors)
+        vectors[fringe, :] = diags([weights], [0], format='csr').dot(
+            vectors[fringe, :])
 
     n_old_plus_new_non_en = len(combined_index) - n_new_english
     result = pd.DataFrame(index=combined_index[0:n_old_plus_new_non_en],


### PR DESCRIPTION
Changes to address the issues identified in code review on May 17, 2018.  The main changes that affect output are (1) modifying the selection of edges used for the full association graph used for propagation (pruning using concept_is_bad) and (2) averaging over non-zero neighbors during propagation (rather than selecting one non-zero neighbor).  Various other changes were made to improve code smells (e.g. refactoring the two use case for the association graph class by introducing two subclasses).

Note that the names of the output files have also been changed, so that the propagated output is now called numberbatch-biased.h5, which is somewhat more in line with the names before the introduction of propagation.
