### PR TITLE
Switch dependency from pg8000 to psycopg2

### DIFF
--- a/conceptnet5/db/config.py
+++ b/conceptnet5/db/config.py
@@ -10,11 +10,10 @@ environment variables:
 """
 import os
 
-DB_USERNAME = os.environ.get('CONCEPTNET_DB_USER', os.environ.get('USER', 'postgres'))
 DB_NAME = os.environ.get('CONCEPTNET_DB_NAME', 'conceptnet5')
-DB_SOCKET = '/var/run/postgresql/.s.PGSQL.5432'
 
-# These will not be used if DB_PASSWORD is blank -- instead, we'll use DB_SOCKET
+# These will not be used if DB_PASSWORD is blank -- instead, we'll use a socket
+DB_USERNAME = os.environ.get('CONCEPTNET_DB_USER', os.environ.get('USER', 'postgres'))
 DB_PASSWORD = os.environ.get('CONCEPTNET_DB_PASSWORD', '')
 DB_HOSTNAME = os.environ.get('CONCEPTNET_DB_HOSTNAME', 'localhost')
 DB_PORT = int(os.environ.get('CONCEPTNET_DB_PORT', '5432'))

--- a/conceptnet5/db/prepare_data.py
+++ b/conceptnet5/db/prepare_data.py
@@ -113,6 +113,6 @@ def load_sql_csv(connection, input_dir):
     ]:
         cursor = connection.cursor()
         with open(filename, 'rb') as file:
-            cursor.execute("COPY %s FROM STDIN" % tablename, stream=file)
+            cursor.copy_from(file, tablename)
         cursor.close()
         connection.commit()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.develop import develop
 import sys
 
 packages = find_packages()
-version_str = '5.6.2'
+version_str = '5.6.3'
 
 if sys.version_info.major < 3:
     print("The ConceptNet 5 code can only run in Python 3.")
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'snakemake', 'click', 'requests', 'ftfy', 'msgpack-python', 'numpy',
         'langcodes >= 1.4.1', 'wordfreq >= 2.0',
-        'xmltodict >= 0.11.0, < 0.12.0', 'ordered_set', 'pg8000',
+        'xmltodict >= 0.11.0, < 0.12.0', 'ordered_set', 'psycopg2-binary',
         'marisa-trie'
     ],
     python_requires='>=3.5',

--- a/tests/small-build/test_queries.py
+++ b/tests/small-build/test_queries.py
@@ -31,6 +31,18 @@ def test_lookup():
     eq_(source['@id'], '/and/[/s/process/split_words/,/s/resource/verbosity/]')
 
 
+def test_null_codepoint():
+    # This test would break pg8000. Thankfully, we're not using it anymore.
+    try:
+        test_finder.lookup('/c/en/denial_of_service\x00attack')
+    except ValueError:
+        # SQL doesn't allow the null codepoint, so it returns an error
+        pass
+
+    # Test that the connection isn't broken
+    assert test_finder.lookup('/c/en/test')
+
+
 def get_query_ids(query):
     return [match['@id'] for match in test_finder.query(query)]
 

--- a/web/setup.py
+++ b/web/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.develop import develop
 import sys
 
 packages = find_packages()
-version_str = '5.6.2'
+version_str = '5.6.3'
 
 if sys.version_info.major < 3:
     print("The ConceptNet 5 code can only run in Python 3.")
@@ -22,7 +22,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'conceptnet >= %s' % version_str,
-        'limits', 'flask==0.11', 'flask-cors', 'flask-limiter',
+        'limits', 'flask==0.12', 'flask-cors', 'flask-limiter',
         'langcodes >= 1.4.1', 'jinja2-highlight', 'pygments', 'raven[flask] >= 6.6'
     ],
     license = 'Apache License 2.0',


### PR DESCRIPTION
This ports ConceptNet's use of PostgreSQL from pg8000 to psycopg2.

It doesn't look like https://github.com/mfenniak/pg8000/issues/159 will be fixed. And psycopg2 now has a binary package that shouldn't cause any particular installation nightmares, so my original reason for choosing pg8000 is moot now anyway.
