### PR TITLE
Propagate tests

### DIFF
--- a/conceptnet5/vectors/propagate.py
+++ b/conceptnet5/vectors/propagate.py
@@ -107,14 +107,18 @@ def make_adjacency_matrix(assoc_filename, embedding_vocab):
     # Put terms from the embedding first, then terms from the good part
     # of the graph neither from the embedding nor in English, then terms
     # from the good part of the graph in English but not from the embedding.
+    #
+    # (In the corner case where either of these addtional sets of terms is
+    # empty, construction of a pandas index will fail using generator rather
+    # than list comprehensions.)
     new_vocab = good_concepts - set(embedding_vocab)
     good_concepts = embedding_vocab.append(
-        pd.Index(term for term in new_vocab
-                 if get_uri_language(term) != 'en'))
+        pd.Index([term for term in new_vocab
+                      if get_uri_language(term) != 'en']))
     n_good_concepts_not_new_en = len(good_concepts)
     good_concepts = good_concepts.append(
-        pd.Index(term for term in new_vocab
-                 if get_uri_language(term) == 'en'))
+        pd.Index([term for term in new_vocab
+                      if get_uri_language(term) == 'en']))
     del new_vocab
     n_new_english = len(good_concepts) - n_good_concepts_not_new_en
     

--- a/conceptnet5/vectors/propagate.py
+++ b/conceptnet5/vectors/propagate.py
@@ -25,12 +25,11 @@ class ConceptNetAssociationGraphForPropagation(ConceptNetAssociationGraph):
     def add_edge(self, left, right, value, dataset, relation):
         """
         In addition to the superclass's handling of a new edge, 
-        saves the edges as a set of (left, right) pairs.  Note that 
-        we do not save (right, left) as well as (left, right) (but also 
-        do not guarantee that only one of the two has been saved).
+        saves the edges as a set of (left, right) pairs.
         """
         super().add_edge(left, right, value, dataset, relation)
         self.edges.add((left, right))
+        self.edges.add((right, left)) # save undirected edges
 
 
 def sharded_propagate(assoc_filename, embedding_filename, 
@@ -137,7 +136,6 @@ def make_adjacency_matrix(assoc_filename, embedding_vocab):
             index0 = good_concepts_map[v]
             index1 = good_concepts_map[w]
             builder[index0, index1] = 1
-            builder[index1, index0] = 1
         except KeyError:
             pass # one of v, w wasn't good
     del graph
@@ -167,16 +165,16 @@ def propagate(combined_index, embedding, adjacency_matrix, n_new_english,
                                   dtype=embedding.values.dtype)])
     
     for iteration in range(iterations):
-        zero_indices = (np.abs(vectors).sum(1) == 0)
-        if not np.any(zero_indices):
+        zero_indicators = (np.abs(vectors).sum(1) == 0)
+        if not np.any(zero_indicators):
             break
         # Find terms with zero vectors having neighbors with nonzero vectors.
-        nonzero_indices = np.logical_not(zero_indices)
-        fringe = (adjacency_matrix.dot(nonzero_indices.astype(np.int8)) != 0)
-        fringe = np.logical_and(fringe, zero_indices)
+        nonzero_indicators = np.logical_not(zero_indicators)
+        fringe = (adjacency_matrix.dot(nonzero_indicators.astype(np.int8)) != 0)
+        fringe = np.logical_and(fringe, zero_indicators)
         # Update each as the average of its nonzero neighbors
         adjacent_nonzeros = adjacency_matrix[fringe, :].dot(
-            diags([nonzero_indices.astype(np.int8)], [0], format='csc'))
+            diags([nonzero_indicators.astype(np.int8)], [0], format='csc'))
         n_adjacent_nonzeros = adjacent_nonzeros.sum(axis=1).A[:, 0]
         weights = 1.0 / n_adjacent_nonzeros
         vectors[fringe, :] = adjacency_matrix[fringe, :].dot(vectors)

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -128,15 +128,15 @@ def retrofit(row_labels, dense_frame, sparse_csr,
     # the first class of terms, so we can't necessarily expect the
     # number of zero vectors to go to zero at any one invocation of
     # this code.
-    n_zero_indices_old = -1
+    n_zero_indicators_old = -1
     for iteration in range(max_cleanup_iters):
-        zero_indices = (np.abs(vecs).sum(1) == 0)
-        n_zero_indices = np.sum(zero_indices)
-        if n_zero_indices == 0 or n_zero_indices == n_zero_indices_old:
+        zero_indicators = (np.abs(vecs).sum(1) == 0)
+        n_zero_indicators = np.sum(zero_indicators)
+        if n_zero_indicators == 0 or n_zero_indicators == n_zero_indicators_old:
             break
-        n_zero_indices_old = n_zero_indices
-        vecs[zero_indices, :] = sparse_csr[zero_indices, :].dot(vecs)
-        normalize(vecs[zero_indices, :], norm='l2', copy=False)
+        n_zero_indicators_old = n_zero_indicators
+        vecs[zero_indicators, :] = sparse_csr[zero_indicators, :].dot(vecs)
+        normalize(vecs[zero_indicators, :], norm='l2', copy=False)
     else:
         print('Warning: cleanup iteration limit exceeded.')
 

--- a/tests/small-build/test_propagate.py
+++ b/tests/small-build/test_propagate.py
@@ -2,20 +2,21 @@ import io
 import numpy as np
 import pandas as pd
 
-from collections import defaultdict
 from conceptnet5.uri import get_uri_language
 from conceptnet5.vectors.propagate import sharded_propagate, make_adjacency_matrix, propagate
-from nose.tools import with_setup, ok_, eq_
 from numpy.testing import assert_allclose
 from scipy import sparse
 from unittest.mock import patch, Mock
 
-N_EMBEDDING_TERMS = 50
+# Constant parameters.
+N_TRIALS = 20
 EMBEDDING_DIM = 4
-N_EXTRA_GRAPH_TERMS = 30
+N_EMBEDDING_TERMS = 25
+N_EXTRA_GRAPH_TERMS = 25
 GRAPH_EDGE_PROBA = 0.25
 LANGUAGES = ['en', 'fr']
-LANGUAGE_PROBA = [0.5, 0.5]
+NON_ENGLISH_LANGUAGES = ['fr', 'zh']
+LANGUAGE_PROBA = [0.8, 0.2]
 WEIGHTS = [0.5, 1.0, 1.5]
 WEIGHT_PROBA = [0.25, 0.5, 0.25]
 DATASETS = ['/d/wiktionary/en', '/d/wiktionary/fr']
@@ -23,16 +24,38 @@ DATASET_PROBA = [0.8, 0.2]
 RELATIONS = ['/r/RelatedTo', '/r/Synonym']
 RELATION_PROBA = [0.75, 0.25]
 
+# Test fixture data (to be setup/torn-down later).
 FRAME = None
-EDGE_LIST = None
+ASSOC_FILE_CONTENTS = None
 EDGE_SET = None
 NEW_ENGLISH_TERMS = None
 NEW_NON_ENGLISH_TERMS = None
 COMBINED_INDEX = None
 ADJACENCY_MATRIX = None
-RANK = None
+RANKS = None
 
-random_gen = np.random.RandomState(101) # fix a random seed
+# Test data will be generated pseudo-randomly, but with a fixed seed to
+# ensure reproducability.
+random_gen = np.random.RandomState(101)
+
+
+def do_setup(setup=None, teardown=None):
+    """
+    A decorator like nose's with_setup, but can be used to wrap functions other 
+    than nose tests.  When a function that has been wrapped by do_setup is 
+    called, the setup function supplied (if any) will be called (with no 
+    arguments), then the decorated function, then the teardown function (if 
+    any, and with no arguments).
+    """
+    def decorate(func):
+        def newfunc(*args, **kwargs):
+            if setup is not None:
+                setup()
+            func(*args, **kwargs)
+            if teardown is not None:
+                teardown()
+        return newfunc
+    return decorate
 
 
 def extract_positional_arg(mock_obj, call_number, position):
@@ -52,102 +75,245 @@ def extract_positional_arg(mock_obj, call_number, position):
 
 
 def make_term(i_term):
+    """
+    Make and return a string representing a (synthetic) term in a randomly-
+    chosen language.
+    """
     language = random_gen.choice(LANGUAGES, p=LANGUAGE_PROBA)
     term = '/c/{}/term{}'.format(language, i_term)
     return term
 
 
-def setup_frame_and_edges():
-    global FRAME, EDGE_LIST, EDGE_SET
-    global NEW_ENGLISH_TERMS, NEW_NON_ENGLISH_TERMS
-    global ADJACENCY_MATRIX, COMBINED_INDEX, RANK
+def make_term_list(length):
+    """
+    Make and return a list of terms, of the requested length, each generated 
+    by make_term.
+    """
+    terms = [make_term(i_term) for i_term in range(length)]
+    return terms
 
-    # Make a frame with synthetic terms and random embedding vectors.
-    terms = [make_term(i_term) for i_term in range(N_EMBEDDING_TERMS + N_EXTRA_GRAPH_TERMS)]
-    frame_index = pd.Index(terms[:N_EMBEDDING_TERMS])
+
+def make_random_frame(terms):
+    """
+    Make a frame with synthetic terms and random embedding vectors.
+    """
+    frame_index = pd.Index(terms)
     frame_data = random_gen.randn(len(frame_index), EMBEDDING_DIM)
-    FRAME = pd.DataFrame(data=frame_data, index=frame_index)
-
-    # Construct a random concept graph by making its set of edges (pairs of
-    # terms) and vertices (single terms), and create an association edge list
-    # for it in the appropriate format for reading by the code under test.
-    EDGE_LIST = []
-    EDGE_SET = set()
-    graph_terms = set()
-    for left in terms:
-        for right in terms:
-            if left == right:
-                continue # make no self-edges
-            if random_gen.uniform() < GRAPH_EDGE_PROBA:
-                weight = random_gen.choice(WEIGHTS, p=WEIGHT_PROBA)
-                dataset = random_gen.choice(DATASETS, p=DATASET_PROBA)
-                rel = random_gen.choice(RELATIONS, p=RELATION_PROBA)
-                EDGE_LIST.append('\t'.join([left, right, str(weight), dataset, rel]))
-                EDGE_SET.add((left, right))
-                EDGE_SET.add((right, left)) # the graph should be undirected
-                graph_terms.add(left)
-                graph_terms.add(right)
-    EDGE_LIST = '\n'.join(EDGE_LIST)
-
-    # Find the sets of terms in the frame, and of additional terms in the
-    # graph not in the frame (keeping in mind that not every term constructed
-    # above may have made it into the graph), in English and not.
-    frame_terms = set(FRAME.index)
-    all_terms = graph_terms | frame_terms
-    new_terms = all_terms - frame_terms
-    NEW_ENGLISH_TERMS = set(
-        term for term in new_terms if get_uri_language(term) == 'en')
-    NEW_NON_ENGLISH_TERMS = new_terms - NEW_ENGLISH_TERMS
-
-    # Make an index containing the terms of the frame, followed by the non-
-    # English terms of the graph not in the frame, followed by the English ones.
-    COMBINED_INDEX = pd.Index(
-        list(frame_terms) + \
-        list(NEW_NON_ENGLISH_TERMS) + \
-        list(NEW_ENGLISH_TERMS)
-    )
-
-    # Make the adjacency matrix of the graph.
-    values = []
-    rows = []
-    cols = []
-    for left in COMBINED_INDEX:
-        for right in COMBINED_INDEX:
-            if (left, right) in EDGE_SET:
-                values.append(np.int8(1))
-                rows.append(COMBINED_INDEX.get_loc(left))
-                cols.append(COMBINED_INDEX.get_loc(right))
-    ADJACENCY_MATRIX = sparse.coo_matrix(
-        (values, (rows, cols)),
-        shape=(len(COMBINED_INDEX), len(COMBINED_INDEX)),
-        dtype=np.int8
-    ).tocsr()
-
-    # Rank the vertices of the graph by their distances from the set of terms
-    # from the frame.
-    RANK = defaultdict(lambda : len(COMBINED_INDEX))
-    for term in FRAME.index:
-        RANK[term] = 0
-    for stage in range(len(new_terms)):
-        for term in new_terms:
-            if RANK[term] <= stage:
-                continue
-            for other_term in COMBINED_INDEX:
-                if (term, other_term) in EDGE_SET and RANK[other_term] <= stage:
-                    RANK[term] = stage + 1
+    frame = pd.DataFrame(data=frame_data, index=frame_index)
+    return frame
 
 
-@with_setup(setup_frame_and_edges)
-def test_adjacency_matrix():
-    with patch('builtins.open', return_value=io.StringIO(EDGE_LIST)):
+class ConceptNetRandomTestGraph:
+    """
+    Instances are randomly-generated association graphs suitable for testing 
+    propagation code.
+    """
+    def __init__(self, initial_terms):
+        """
+        Construct a random concept graph by making its set of edges (pairs of
+        terms) and vertices (single terms), and create an association edge list
+        for it in the appropriate format for reading by the code under test.  
+        Note that the resulting set of vertices/terms may be a proper subset of 
+        the initial terms supplied, as we do not include vertices without any 
+        incident edges in the output.
+        """
+        # Represent the graph as simply as possible, namely with a set of
+        # vertices (terms) and a set of edges (pairs of vertices).
+        self.vertices = set()
+        self.edge_set = set()
+
+        # But we also need a representation of the graph readable as an
+        # assoc file to feed to code to be tested.
+        self.assoc_file_contents = []
+        
+        for left in initial_terms:
+            for right in initial_terms:
+                if left <= right:
+                    continue # make no self-edges, consider each pair only once
+                if random_gen.uniform() < GRAPH_EDGE_PROBA:
+                    weight = random_gen.choice(WEIGHTS, p=WEIGHT_PROBA)
+                    dataset = random_gen.choice(DATASETS, p=DATASET_PROBA)
+                    rel = random_gen.choice(RELATIONS, p=RELATION_PROBA)
+                    self.assoc_file_contents.append('\t'.join([left, right, str(weight), dataset, rel]))
+                    self.edge_set.add((left, right))
+                    self.edge_set.add((right, left)) # make the graph undirected
+                    self.vertices.add(left)
+                    self.vertices.add(right)
+        self.assoc_file_contents = '\n'.join(self.assoc_file_contents)
+
+    def combined_index_and_new_term_sets(self, frame):
+        """
+        Find the sets of terms in the frame, and of additional terms in the
+        graph not in the frame, but at finite distance in the graph from the 
+        terms of the frame, in English and not.  Using these construct a 
+        combined index satisfying the constraints required for input to 
+        propagation (terms of the frame must come first, then terms from the 
+        (vertices of) the graph not in the frame, with the non-English terms 
+        not from the frame preceeding the English terms not from the frame).
+        
+        Returns the combined index, the set of non-English terms from the 
+        graph not in the frame, and the set of English terms from the graph 
+        not in the frame.
+        """
+        frame_terms = set(frame.index)
+
+        # Get the ranks of the vertices of the graph with respect to the frame,
+        # and use them to eliminate all vertices not a finite distance from the
+        # frame.
+        ranks = self.rank_vertices(frame)
+        graph_terms = set(term for term in self.vertices if ranks[term] != -1)
+        
+        all_terms = graph_terms | frame_terms
+        new_terms = all_terms - frame_terms
+        new_english_terms = set(
+            term for term in new_terms if get_uri_language(term) == 'en'
+        )
+        new_non_english_terms = new_terms - new_english_terms
+
+        combined_index = pd.Index(
+            list(frame_terms) + \
+            list(new_non_english_terms) + \
+            list(new_english_terms)
+        )
+        return combined_index, new_non_english_terms, new_english_terms
+
+    def adjacency_matrix(self, combined_index):
+        """
+        Return the adjacency matrix of the graph with respect to the given 
+        index.  That is, a (sparse) square matrix with one row and column for 
+        each entry in the index, such that any entry is one if and only if the 
+        corresponding terms from the index are joined by an edge in the graph.
+        """
+        values = []
+        rows = []
+        cols = []
+        for left in combined_index:
+            for right in combined_index:
+                if (left, right) in self.edge_set:
+                    values.append(np.int8(1))
+                    rows.append(combined_index.get_loc(left))
+                    cols.append(combined_index.get_loc(right))
+        
+        adjacency_matrix = sparse.coo_matrix(
+            (values, (rows, cols)),
+            shape=(len(combined_index), len(combined_index)),
+            dtype=np.int8
+        ).tocsr()
+        return adjacency_matrix
+
+    def rank_vertices(self, frame):
+        """
+        Rank the vertices of the graph by their distances from the set of terms
+        from the frame, and return a dict mapping each vertex to its rank.  
+        (Vertices not at a finite distance from the frame will be assigned a 
+        rank of -1.)
+        """
+        # Let ranks default to a value larger than any possible valid rank.
+        bigger_than_any_rank = len(self.vertices)
+        ranks = {vertex : bigger_than_any_rank for vertex in self.vertices}
+
+        # But terms from the frame have rank 0.
+        for term in frame.index:
+            ranks[term] = 0
+
+        # If any edge has a rank difference more than one, reduce the rank of
+        # the higher-ranked end to make the difference one.  This leaves every
+        # vertex assigned a rank greater or equal to its true rank.  Repeat
+        # until there are no more such differences; then every vertex assigned
+        # rank zero is truly rank zero, every vertex assigned rank one is truly
+        # rank one, etc.
+        done = False
+        while not done:
+            done = True
+            for left, right in self.edge_set:
+                if ranks[left] > ranks[right] + 1:
+                    ranks[left] = ranks[right] + 1
+                    done = False
+                elif ranks[right] > ranks[left] + 1:
+                    ranks[right] = ranks[left] + 1
+                    done = False
+
+        for vertex, r in ranks.items():
+            if r == bigger_than_any_rank:
+                ranks[vertex] = -1
+        return ranks
+
+
+# Setup and teardown functions to create/erase a single test data instance.
+
+def setup_frame_and_edges():
+    global FRAME, ASSOC_FILE_CONTENTS, EDGE_SET
+    initial_terms = make_term_list(N_EMBEDDING_TERMS + N_EXTRA_GRAPH_TERMS)
+    FRAME = make_random_frame(initial_terms[:N_EMBEDDING_TERMS])
+    graph = ConceptNetRandomTestGraph(initial_terms)
+    ASSOC_FILE_CONTENTS = graph.assoc_file_contents
+    EDGE_SET = graph.edge_set
+
+def setup_combined_index():
+    global FRAME, ASSOC_FILE_CONTENTS
+    global COMBINED_INDEX, NEW_ENGLISH_TERMS, NEW_NON_ENGLISH_TERMS
+    initial_terms = make_term_list(N_EMBEDDING_TERMS + N_EXTRA_GRAPH_TERMS)
+    FRAME = make_random_frame(initial_terms[:N_EMBEDDING_TERMS])
+    graph = ConceptNetRandomTestGraph(initial_terms)
+    ASSOC_FILE_CONTENTS = graph.assoc_file_contents
+    COMBINED_INDEX, NEW_NON_ENGLISH_TERMS, NEW_ENGLISH_TERMS = \
+        graph.combined_index_and_new_term_sets(FRAME)
+
+def setup_adjacency_matrix():
+    global FRAME, ASSOC_FILE_CONTENTS
+    global COMBINED_INDEX, NEW_ENGLISH_TERMS, NEW_NON_ENGLISH_TERMS
+    global ADJACENCY_MATRIX
+    initial_terms = make_term_list(N_EMBEDDING_TERMS + N_EXTRA_GRAPH_TERMS)
+    FRAME = make_random_frame(initial_terms[:N_EMBEDDING_TERMS])
+    graph = ConceptNetRandomTestGraph(initial_terms)
+    ASSOC_FILE_CONTENTS = graph.assoc_file_contents
+    COMBINED_INDEX, NEW_NON_ENGLISH_TERMS, NEW_ENGLISH_TERMS = \
+        graph.combined_index_and_new_term_sets(FRAME)
+    ADJACENCY_MATRIX = graph.adjacency_matrix(COMBINED_INDEX)
+
+def setup_ranks():
+    global FRAME, ASSOC_FILE_CONTENTS, EDGE_SET
+    global COMBINED_INDEX, NEW_ENGLISH_TERMS, NEW_NON_ENGLISH_TERMS
+    global ADJACENCY_MATRIX, RANKS
+    initial_terms = make_term_list(N_EMBEDDING_TERMS + N_EXTRA_GRAPH_TERMS)
+    FRAME = make_random_frame(initial_terms[:N_EMBEDDING_TERMS])
+    graph = ConceptNetRandomTestGraph(initial_terms)
+    ASSOC_FILE_CONTENTS = graph.assoc_file_contents
+    EDGE_SET = graph.edge_set
+    COMBINED_INDEX, NEW_NON_ENGLISH_TERMS, NEW_ENGLISH_TERMS = \
+        graph.combined_index_and_new_term_sets(FRAME)
+    ADJACENCY_MATRIX = graph.adjacency_matrix(COMBINED_INDEX)
+    RANKS = graph.rank_vertices(FRAME)
+
+def teardown_all():
+    global FRAME, ASSOC_FILE_CONTENTS, EDGE_SET
+    global COMBINED_INDEX, NEW_ENGLISH_TERMS, NEW_NON_ENGLISH_TERMS
+    global ADJACENCY_MATRIX, RANKS
+    FRAME = None
+    ASSOC_FILE_CONTENTS = None
+    EDGE_SET = None
+    COMBINED_INDEX = None
+    NEW_ENGLISH_TERMS = None
+    NEW_NON_ENGLISH_TERMS = None
+    ADJACENCY_MATRIX = None
+    RANKS = None
+
+
+@do_setup(setup_frame_and_edges, teardown_all)
+def do_single_test_adjacency_matrix():
+    # Call the code under test, but feed it an association list from the test
+    # fixture rather than from a file.
+    with patch('builtins.open', return_value=io.StringIO(ASSOC_FILE_CONTENTS)):
         adjacency_matrix, combined_index, n_new_english = make_adjacency_matrix(
             'ignored_filename', FRAME.index)
     
     # The adjacency matrix must be square with one row for each term in the
     # combined index.
-    eq_(len(adjacency_matrix.shape), 2)
-    eq_(adjacency_matrix.shape[0], len(combined_index))
-    eq_(adjacency_matrix.shape[1], len(combined_index))
+    assert (len(adjacency_matrix.shape) == 2), 'Adjacency matrix must be 2D.'
+    assert (adjacency_matrix.shape[0] == len(combined_index)), \
+        'Adjacency matrix must have one row for each term of the combined index.'
+    assert (adjacency_matrix.shape[1] == len(combined_index)), \
+        'Adjacency matrix must have one column for each term of the combined index.'
 
     # Each entry must be 0 or 1 according to whether the corresponding terms
     # are joined by an edge in the graph.  Note that it is problematic to
@@ -159,39 +325,52 @@ def test_adjacency_matrix():
             right = combined_index[i_right]
             is_edge = (left, right) in EDGE_SET
             entry = adjacency_matrix[i_left, i_right]
-            ok_((entry == 0) or (entry == 1))
-            eq_(entry == 1, is_edge)
+            assert ((entry == 0) or (entry == 1)), \
+                'Invalid entry {} in adjacency matrix at row {} ({}) and column {} ({}).'.format(entry, i_left, left, i_right, right)
+            if (left, right) in EDGE_SET:
+                assert (entry == 1), \
+                    'Edge between {} (row {}) and {} (column {}) missing in adjacency matrix.'.format(left, i_left, right, i_right)
+            else:
+                assert (entry == 0), \
+                    'Adjacency matrix incorrectly indicates an edge between {} (row {}) and {} (column {}).'.format(left, i_left, right, i_right)
 
 
-@with_setup(setup_frame_and_edges)
-def test_combined_index():
-    with patch('builtins.open', return_value=io.StringIO(EDGE_LIST)):
+@do_setup(setup_combined_index, teardown_all)
+def do_single_test_combined_index():
+    # Call the code under test, but feed it an association list from the test
+    # fixture rather than from a file.
+    with patch('builtins.open', return_value=io.StringIO(ASSOC_FILE_CONTENTS)):
         adjacency_matrix, combined_index, n_new_english = make_adjacency_matrix(
             'ignored_filename', FRAME.index)
 
     # The computed combined index must have the same terms as the reference,
     # but possibly in a different order.
-    eq_(set(combined_index), set(COMBINED_INDEX))
+    assert (set(combined_index) == set(COMBINED_INDEX)), \
+        'Computed combined index has incorrect terms.'
 
     # No term should be listed twice in the combined index.
-    eq_(len(combined_index), len(set(combined_index)))
+    assert (len(combined_index) == len(set(combined_index))), \
+        'Computed combined index has repeated terms.'
 
     # The terms from the frame must preceed any other terms from the graph.
     n_frame_terms = len(FRAME.index)
-    eq_(set(combined_index[:n_frame_terms]), set(FRAME.index))
+    assert (set(combined_index[:n_frame_terms]) == set(FRAME.index)), \
+        'Computed combined index does not start with the original terms from the embedding.'
 
     # Among the remaining terms, the terms in English must come last, and
     # their number must be reported correctly.
-    eq_(n_new_english, len(NEW_ENGLISH_TERMS))
+    assert (n_new_english == len(NEW_ENGLISH_TERMS)), \
+        'Incorrect number {} (should be {}) of new terms from the association graph in English.'.format(n_new_english, len(NEW_ENGLISH_TERMS))
     n_new_non_english = len(NEW_NON_ENGLISH_TERMS)
-    eq_(set(combined_index[n_frame_terms:(n_frame_terms + n_new_non_english)]),
-        NEW_NON_ENGLISH_TERMS)
-    eq_(set(combined_index[(n_frame_terms + n_new_non_english):]),
-        NEW_ENGLISH_TERMS)
+    assert (set(combined_index[n_frame_terms:(n_frame_terms + n_new_non_english)]) == NEW_NON_ENGLISH_TERMS), \
+        'Incorrect list of new terms from the association graph not in English.'
+    assert (set(combined_index[(n_frame_terms + n_new_non_english):]) == NEW_ENGLISH_TERMS), \
+        'Incorrect list of new terms from the association graph in English.'
 
 
-@with_setup(setup_frame_and_edges)
-def test_propagate():
+@do_setup(setup_ranks, teardown_all)
+def do_single_test_propagate():
+    # Call the code under test.
     propagated = propagate(
         COMBINED_INDEX, FRAME, ADJACENCY_MATRIX, len(NEW_ENGLISH_TERMS)
     )
@@ -199,12 +378,15 @@ def test_propagate():
     # The propagated terms should be the terms from the conbined index,
     # starting with the terms of the frame and going up to the last new
     # term from the graph that is not in English.
-    eq_(len(propagated), len(FRAME) + len(NEW_NON_ENGLISH_TERMS))
+    assert (len(propagated) == len(FRAME) + len(NEW_NON_ENGLISH_TERMS)), \
+        'Incorrect number {} (should be {}) of propataged terms.'.format(len(propagated), len(FRAME) + len(NEW_NON_ENGLISH_TERMS))
     for i_term in range(len(propagated)):
-        eq_(propagated.index[i_term], COMBINED_INDEX[i_term])
+        assert (propagated.index[i_term] == COMBINED_INDEX[i_term]), \
+            'Propagated output terms do not agree with the input terms.'
     
     # The original embedding should not be altered.
-    assert_allclose(propagated.values[:len(FRAME), :], FRAME.values)
+    assert_allclose(propagated.values[:len(FRAME), :], FRAME.values,
+                    err_msg='Propagation changed an input embedding vector.')
 
     # Terms not from the original embedding should be assigned the 
     # average of the vectors of their neighbors of lesser rank, if all
@@ -216,26 +398,29 @@ def test_propagate():
         for other_term in COMBINED_INDEX:
             if (
                 (term, other_term) in EDGE_SET
-                    and RANK[other_term] < RANK[term]
+                    and RANKS[other_term] < RANKS[term]
             ):
                 if other_term in NEW_ENGLISH_TERMS:
                     break
                 count += 1
                 sum = np.add(sum, propagated.loc[other_term])
         else:
-            assert_allclose(propagated.loc[term], sum/count)
+            assert_allclose(
+                propagated.loc[term], sum/count,
+                err_msg='Incorrect propagated vector for term {}'.format(term)
+            )
 
 
-@with_setup(setup_frame_and_edges)
-def test_sharded_propagate():
+@do_setup(setup_adjacency_matrix, teardown_all)
+def do_single_test_sharded_propagate():
     # Run the sharded propagation code over the test data in 2 shards.
     nshards = 2
-    shard_catcher = Mock(return_value=None)
-    with patch('builtins.open', return_value=io.StringIO(EDGE_LIST)), \
+    shard_collector = Mock(return_value=None)
+    with patch('builtins.open', return_value=io.StringIO(ASSOC_FILE_CONTENTS)), \
          patch('conceptnet5.vectors.propagate.make_adjacency_matrix',
                return_value=(ADJACENCY_MATRIX, COMBINED_INDEX, len(NEW_ENGLISH_TERMS))), \
          patch('conceptnet5.vectors.propagate.load_hdf', return_value=FRAME), \
-         patch('conceptnet5.vectors.propagate.save_hdf', shard_catcher):
+         patch('conceptnet5.vectors.propagate.save_hdf', shard_collector):
         sharded_propagate(
             'ignored_assoc_file',
             'ignored_embedding_file',
@@ -251,17 +436,59 @@ def test_sharded_propagate():
     # Check that two shard files were written, to the correct filenames.
     shard_arg = 0  # shard is 1st arg to save_hdf
     fname_arg = 1  # filename is 2nd arg to save_hdf.
-    eq_(len(shard_catcher.call_args_list), nshards)
+    assert (len(shard_collector.call_args_list) == nshards), \
+        'Incorrect number {} (should be {}) of shards written.'.format(
+            len(shard_collector.call_args_list), nshards)
     for i_shard in range(nshards):
-        filename = extract_positional_arg(shard_catcher, i_shard, fname_arg)
-        eq_(filename, 'shard_filename_root.shard{}'.format(i_shard))
+        filename = extract_positional_arg(shard_collector, i_shard, fname_arg)
+        assert (filename == 'shard_filename_root.shard{}'.format(i_shard)), \
+            'Shard {} written to incorrect file name {}.'.format(i_shard, filename)
 
     # The shards should agree with the appropriate pieces of the unsharded output.
     for i_shard in range(nshards):
-        shard = extract_positional_arg(shard_catcher, i_shard, shard_arg)
+        shard = extract_positional_arg(shard_collector, i_shard, shard_arg)
         shard_start_dim = i_shard * EMBEDDING_DIM // nshards
         shard_end_dim = shard_start_dim + EMBEDDING_DIM // nshards
-        eq_(len(shard.index), len(propagated.index))
+        assert (len(shard.index) == len(propagated.index)), \
+            'Shard {} has incorrect length {} (should be {}).'.format(
+                i_shard, len(shard.index), len(propagated.index))
         for shard_term, ref_term in zip(shard.index, propagated.index):
-            eq_(shard_term, ref_term)
-        assert_allclose(shard.values, propagated.values[:, shard_start_dim:shard_end_dim])
+            assert (shard_term == ref_term), \
+                'Shard {} has term {} where reference has {}.'.format(
+                    i_shard, shard_term, ref_term)
+        assert_allclose(
+            shard.values, propagated.values[:, shard_start_dim:shard_end_dim],
+            err_msg='Shard {} has incorrect propagated vectors.'.format(i_shard)
+        )
+
+
+# The test functions generate multiple instances of test data and apply
+# lower-level individual tests to each.
+
+def test_adjacency_matrix():
+    for i_test in range(N_TRIALS):
+        do_single_test_adjacency_matrix()
+
+def test_combined_index():
+    for i_test in range(N_TRIALS):
+        do_single_test_combined_index()
+
+def test_propagate():
+    # It is useful to test propagation on graphs with no English terms,
+    # where every term's propagated output vector is computable from its
+    # output neighbors (and the ranking of the graph).  (By comparison,
+    # if there are new English terms their propagated values do not appear
+    # in the propagation output and so their neighbors' values cannot
+    # necessarily be computed just from the propagation output.)
+    global LANGUAGES
+    for i_test in range(N_TRIALS):
+        do_single_test_propagate()
+    saved_languages = LANGUAGES
+    LANGUAGES = NON_ENGLISH_LANGUAGES
+    for i_test in range(N_TRIALS):
+        do_single_test_propagate()
+    LANGUAGES = saved_languages
+
+def test_sharded_propagate():
+    for i_test in range(N_TRIALS):
+        do_single_test_sharded_propagate()

--- a/tests/small-build/test_propagate.py
+++ b/tests/small-build/test_propagate.py
@@ -436,7 +436,7 @@ def single_test_propagate():
     # starting with the terms of the frame and going up to the last new
     # term from the graph that is not in English.
     assert (len(propagated) == len(FRAME) + len(NEW_NON_ENGLISH_TERMS)), \
-        'Incorrect number {} (should be {}) of propataged terms.'.format(len(propagated), len(FRAME) + len(NEW_NON_ENGLISH_TERMS))
+        'Incorrect number {} (should be {}) of propagated terms.'.format(len(propagated), len(FRAME) + len(NEW_NON_ENGLISH_TERMS))
     for i_term in range(len(propagated)):
         assert (propagated.index[i_term] == COMBINED_INDEX[i_term]), \
             'Propagated output terms do not agree with the input terms.'

--- a/tests/small-build/test_propagate.py
+++ b/tests/small-build/test_propagate.py
@@ -1,0 +1,267 @@
+import io
+import numpy as np
+import pandas as pd
+
+from collections import defaultdict
+from conceptnet5.uri import get_uri_language
+from conceptnet5.vectors.propagate import sharded_propagate, make_adjacency_matrix, propagate
+from nose.tools import with_setup, ok_, eq_
+from numpy.testing import assert_allclose
+from scipy import sparse
+from unittest.mock import patch, Mock
+
+N_EMBEDDING_TERMS = 50
+EMBEDDING_DIM = 4
+N_EXTRA_GRAPH_TERMS = 30
+GRAPH_EDGE_PROBA = 0.25
+LANGUAGES = ['en', 'fr']
+LANGUAGE_PROBA = [0.5, 0.5]
+WEIGHTS = [0.5, 1.0, 1.5]
+WEIGHT_PROBA = [0.25, 0.5, 0.25]
+DATASETS = ['/d/wiktionary/en', '/d/wiktionary/fr']
+DATASET_PROBA = [0.8, 0.2]
+RELATIONS = ['/r/RelatedTo', '/r/Synonym']
+RELATION_PROBA = [0.75, 0.25]
+
+FRAME = None
+EDGE_LIST = None
+EDGE_SET = None
+NEW_ENGLISH_TERMS = None
+NEW_NON_ENGLISH_TERMS = None
+COMBINED_INDEX = None
+ADJACENCY_MATRIX = None
+RANK = None
+
+random_gen = np.random.RandomState(101) # fix a random seed
+
+
+def extract_positional_arg(mock_obj, call_number, position):
+    """
+    Given a unittest.mock object (which has been used to mock some callable), 
+    a call number (less than the number of times the mock object has been 
+    called) and a position, return the positional argument at that position 
+    for the given call of the object.
+    """
+    if len(mock_obj.call_args_list) <= call_number:
+        return None
+    call_args = mock_obj.call_args_list[call_number]
+    positional_args = call_args[0]
+    if len(positional_args) <= position:
+        return None
+    return positional_args[position]
+
+
+def make_term(i_term):
+    language = random_gen.choice(LANGUAGES, p=LANGUAGE_PROBA)
+    term = '/c/{}/term{}'.format(language, i_term)
+    return term
+
+
+def setup_frame_and_edges():
+    global FRAME, EDGE_LIST, EDGE_SET
+    global NEW_ENGLISH_TERMS, NEW_NON_ENGLISH_TERMS
+    global ADJACENCY_MATRIX, COMBINED_INDEX, RANK
+
+    # Make a frame with synthetic terms and random embedding vectors.
+    terms = [make_term(i_term) for i_term in range(N_EMBEDDING_TERMS + N_EXTRA_GRAPH_TERMS)]
+    frame_index = pd.Index(terms[:N_EMBEDDING_TERMS])
+    frame_data = random_gen.randn(len(frame_index), EMBEDDING_DIM)
+    FRAME = pd.DataFrame(data=frame_data, index=frame_index)
+
+    # Construct a random concept graph by making its set of edges (pairs of
+    # terms) and vertices (single terms), and create an association edge list
+    # for it in the appropriate format for reading by the code under test.
+    EDGE_LIST = []
+    EDGE_SET = set()
+    graph_terms = set()
+    for left in terms:
+        for right in terms:
+            if left == right:
+                continue # make no self-edges
+            if random_gen.uniform() < GRAPH_EDGE_PROBA:
+                weight = random_gen.choice(WEIGHTS, p=WEIGHT_PROBA)
+                dataset = random_gen.choice(DATASETS, p=DATASET_PROBA)
+                rel = random_gen.choice(RELATIONS, p=RELATION_PROBA)
+                EDGE_LIST.append('\t'.join([left, right, str(weight), dataset, rel]))
+                EDGE_SET.add((left, right))
+                EDGE_SET.add((right, left)) # the graph should be undirected
+                graph_terms.add(left)
+                graph_terms.add(right)
+    EDGE_LIST = '\n'.join(EDGE_LIST)
+
+    # Find the sets of terms in the frame, and of additional terms in the
+    # graph not in the frame (keeping in mind that not every term constructed
+    # above may have made it into the graph), in English and not.
+    frame_terms = set(FRAME.index)
+    all_terms = graph_terms | frame_terms
+    new_terms = all_terms - frame_terms
+    NEW_ENGLISH_TERMS = set(
+        term for term in new_terms if get_uri_language(term) == 'en')
+    NEW_NON_ENGLISH_TERMS = new_terms - NEW_ENGLISH_TERMS
+
+    # Make an index containing the terms of the frame, followed by the non-
+    # English terms of the graph not in the frame, followed by the English ones.
+    COMBINED_INDEX = pd.Index(
+        list(frame_terms) + \
+        list(NEW_NON_ENGLISH_TERMS) + \
+        list(NEW_ENGLISH_TERMS)
+    )
+
+    # Make the adjacency matrix of the graph.
+    values = []
+    rows = []
+    cols = []
+    for left in COMBINED_INDEX:
+        for right in COMBINED_INDEX:
+            if (left, right) in EDGE_SET:
+                values.append(np.int8(1))
+                rows.append(COMBINED_INDEX.get_loc(left))
+                cols.append(COMBINED_INDEX.get_loc(right))
+    ADJACENCY_MATRIX = sparse.coo_matrix(
+        (values, (rows, cols)),
+        shape=(len(COMBINED_INDEX), len(COMBINED_INDEX)),
+        dtype=np.int8
+    ).tocsr()
+
+    # Rank the vertices of the graph by their distances from the set of terms
+    # from the frame.
+    RANK = defaultdict(lambda : len(COMBINED_INDEX))
+    for term in FRAME.index:
+        RANK[term] = 0
+    for stage in range(len(new_terms)):
+        for term in new_terms:
+            if RANK[term] <= stage:
+                continue
+            for other_term in COMBINED_INDEX:
+                if (term, other_term) in EDGE_SET and RANK[other_term] <= stage:
+                    RANK[term] = stage + 1
+
+
+@with_setup(setup_frame_and_edges)
+def test_adjacency_matrix():
+    with patch('builtins.open', return_value=io.StringIO(EDGE_LIST)):
+        adjacency_matrix, combined_index, n_new_english = make_adjacency_matrix(
+            'ignored_filename', FRAME.index)
+    
+    # The adjacency matrix must be square with one row for each term in the
+    # combined index.
+    eq_(len(adjacency_matrix.shape), 2)
+    eq_(adjacency_matrix.shape[0], len(combined_index))
+    eq_(adjacency_matrix.shape[1], len(combined_index))
+
+    # Each entry must be 0 or 1 according to whether the corresponding terms
+    # are joined by an edge in the graph.  Note that it is problematic to
+    # compare entries directly with the reference ADJACENCY_MATRIX as its
+    # rows and columns may be permuted with respect to the computed matrix.
+    for i_left in range(len(combined_index)):
+        left = combined_index[i_left]
+        for i_right in range(len(combined_index)):
+            right = combined_index[i_right]
+            is_edge = (left, right) in EDGE_SET
+            entry = adjacency_matrix[i_left, i_right]
+            ok_((entry == 0) or (entry == 1))
+            eq_(entry == 1, is_edge)
+
+
+@with_setup(setup_frame_and_edges)
+def test_combined_index():
+    with patch('builtins.open', return_value=io.StringIO(EDGE_LIST)):
+        adjacency_matrix, combined_index, n_new_english = make_adjacency_matrix(
+            'ignored_filename', FRAME.index)
+
+    # The computed combined index must have the same terms as the reference,
+    # but possibly in a different order.
+    eq_(set(combined_index), set(COMBINED_INDEX))
+
+    # No term should be listed twice in the combined index.
+    eq_(len(combined_index), len(set(combined_index)))
+
+    # The terms from the frame must preceed any other terms from the graph.
+    n_frame_terms = len(FRAME.index)
+    eq_(set(combined_index[:n_frame_terms]), set(FRAME.index))
+
+    # Among the remaining terms, the terms in English must come last, and
+    # their number must be reported correctly.
+    eq_(n_new_english, len(NEW_ENGLISH_TERMS))
+    n_new_non_english = len(NEW_NON_ENGLISH_TERMS)
+    eq_(set(combined_index[n_frame_terms:(n_frame_terms + n_new_non_english)]),
+        NEW_NON_ENGLISH_TERMS)
+    eq_(set(combined_index[(n_frame_terms + n_new_non_english):]),
+        NEW_ENGLISH_TERMS)
+
+
+@with_setup(setup_frame_and_edges)
+def test_propagate():
+    propagated = propagate(
+        COMBINED_INDEX, FRAME, ADJACENCY_MATRIX, len(NEW_ENGLISH_TERMS)
+    )
+
+    # The propagated terms should be the terms from the conbined index,
+    # starting with the terms of the frame and going up to the last new
+    # term from the graph that is not in English.
+    eq_(len(propagated), len(FRAME) + len(NEW_NON_ENGLISH_TERMS))
+    for i_term in range(len(propagated)):
+        eq_(propagated.index[i_term], COMBINED_INDEX[i_term])
+    
+    # The original embedding should not be altered.
+    assert_allclose(propagated.values[:len(FRAME), :], FRAME.values)
+
+    # Terms not from the original embedding should be assigned the 
+    # average of the vectors of their neighbors of lesser rank, if all
+    # of those neighbors are either from the original embedding or non-
+    # English.
+    for term in NEW_NON_ENGLISH_TERMS:
+        count = 0
+        sum = np.zeros((EMBEDDING_DIM,), dtype=np.float32)
+        for other_term in COMBINED_INDEX:
+            if (
+                (term, other_term) in EDGE_SET
+                    and RANK[other_term] < RANK[term]
+            ):
+                if other_term in NEW_ENGLISH_TERMS:
+                    break
+                count += 1
+                sum = np.add(sum, propagated.loc[other_term])
+        else:
+            assert_allclose(propagated.loc[term], sum/count)
+
+
+@with_setup(setup_frame_and_edges)
+def test_sharded_propagate():
+    # Run the sharded propagation code over the test data in 2 shards.
+    nshards = 2
+    shard_catcher = Mock(return_value=None)
+    with patch('builtins.open', return_value=io.StringIO(EDGE_LIST)), \
+         patch('conceptnet5.vectors.propagate.make_adjacency_matrix',
+               return_value=(ADJACENCY_MATRIX, COMBINED_INDEX, len(NEW_ENGLISH_TERMS))), \
+         patch('conceptnet5.vectors.propagate.load_hdf', return_value=FRAME), \
+         patch('conceptnet5.vectors.propagate.save_hdf', shard_catcher):
+        sharded_propagate(
+            'ignored_assoc_file',
+            'ignored_embedding_file',
+            'shard_filename_root',
+            nshards=nshards
+        )
+
+    # Run unsharded propagation for comparison.
+    propagated = propagate(
+        COMBINED_INDEX, FRAME, ADJACENCY_MATRIX, len(NEW_ENGLISH_TERMS)
+    )
+
+    # Check that two shard files were written, to the correct filenames.
+    shard_arg = 0  # shard is 1st arg to save_hdf
+    fname_arg = 1  # filename is 2nd arg to save_hdf.
+    eq_(len(shard_catcher.call_args_list), nshards)
+    for i_shard in range(nshards):
+        filename = extract_positional_arg(shard_catcher, i_shard, fname_arg)
+        eq_(filename, 'shard_filename_root.shard{}'.format(i_shard))
+
+    # The shards should agree with the appropriate pieces of the unsharded output.
+    for i_shard in range(nshards):
+        shard = extract_positional_arg(shard_catcher, i_shard, shard_arg)
+        shard_start_dim = i_shard * EMBEDDING_DIM // nshards
+        shard_end_dim = shard_start_dim + EMBEDDING_DIM // nshards
+        eq_(len(shard.index), len(propagated.index))
+        for shard_term, ref_term in zip(shard.index, propagated.index):
+            eq_(shard_term, ref_term)
+        assert_allclose(shard.values, propagated.values[:, shard_start_dim:shard_end_dim])


### PR DESCRIPTION
Adds a new file to the small build tests that runs tests of the propagation code.  Also includes minor changes to the code under test to fix some corner cases that show up in testing (but would be unlikely to arise in practice).  Changed the name of variables in propagation and retrofitting code (to improve clarity).
