### PR TITLE
Shard-oblivious retrofitting.

### DIFF
--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -51,15 +51,17 @@ def filter_word_vectors(dense_hdf_filename, vocab_filename):
 @click.option('--nshards', '-n', default=6)
 @click.option('--verbose', '-v', count=True)
 @click.option('--max_cleanup_iters', '-m', default=20)
+@click.option('--orig_vec_weight', '-w', default=0.15)
 def run_retrofit(dense_hdf_filename, conceptnet_filename, output_filename,
-                 iterations=5, nshards=6, verbose=0, max_cleanup_iters=20):
+                 iterations=5, nshards=6, verbose=0, max_cleanup_iters=20,
+                 orig_vec_weight=0.15):
     """
     Run retrofit, operating on a part of a frame at a time.
     """
     sharded_retrofit(
         dense_hdf_filename, conceptnet_filename, output_filename,
         iterations=iterations, nshards=nshards, verbosity=verbose,
-        max_cleanup_iters=max_cleanup_iters
+        max_cleanup_iters=max_cleanup_iters, orig_vec_weight=orig_vec_weight
     )
 
 

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import numpy as np
-import math
 from sklearn.preprocessing import normalize
 from .sparse_matrix_builder import build_from_conceptnet_table
 from .formats import load_hdf, save_hdf


### PR DESCRIPTION
Removed L^2 renormalization of embedding vectors during retrofitting, to make the results (essentially) invariant of the number of shards used.  Replaced that normalization with scaling based on the weights from the ConceptNet graph (taking into account which concepts have non-zero vectors).  Added an argument to retrofitting controlling the relative weights assigned to the vectors from the original embeddings and the updates derived from the graph edges.
