### PR TITLE
Fix Kyoto/Yahoo reader bug

### DIFF
--- a/conceptnet5/readers/kyoto_yahoo.py
+++ b/conceptnet5/readers/kyoto_yahoo.py
@@ -26,7 +26,7 @@ def handle_file(input_filename, output_file):
         parts = line.rstrip('\n').split('\t')
         uri, start, rel, end, weight, source = parts
         if uri == 'uri':
-            return
+            continue
 
         edge = make_edge(
             rel=rel,

--- a/conceptnet5/vectors/evaluation/wordsim.py
+++ b/conceptnet5/vectors/evaluation/wordsim.py
@@ -500,7 +500,8 @@ def read_rw(subset='dev'):
 
 def read_jsim():
     """
-    Read the Japanese rare-words dataset from Tokyo Metropolitan University.
+    Read the updated Japanese rare-words dataset from Karpinska et al.
+    (http://www.aclweb.org/anthology/W18-2905)
     """
     lang1, lang2 = 'ja', 'ja'
     for pos in ('noun', 'verb', 'adj', 'adv'):

--- a/testdata/raw/kyoto_yahoo/facts.tsv
+++ b/testdata/raw/kyoto_yahoo/facts.tsv
@@ -1,3 +1,4 @@
+uri	rel	start	end	weight	source
 /a/[/c/ja/α_テスト,/r/IsA,/c/ja/テスト]	/c/ja/α_テスト	/r/IsA	/c/ja/テスト	3	Kyoto University & Yahoo Japan Corporation
 /a/[/c/ja/α_テスト,/r/IsA,/c/ja/試験]	/c/ja/α_テスト	/r/IsA	/c/ja/試験	3	Kyoto University & Yahoo Japan Corporation
 /a/[/c/ja/β_テスト,/r/IsA,/c/ja/テスト]	/c/ja/β_テスト	/r/IsA	/c/ja/テスト	4	Kyoto University & Yahoo Japan Corporation

--- a/tests/small-build/test_json_ld.py
+++ b/tests/small-build/test_json_ld.py
@@ -44,7 +44,7 @@ def vocab(name):
     Given a property such as 'rel', get its fully-qualified URL in our
     JSON-LD vocabulary.
     """
-    return "http://api.conceptnet.io/ld/conceptnet5.6/context.ld.json#" + name
+    return "http://api.conceptnet.io/ld/conceptnet5.7/context.ld.json#" + name
 
 
 def api(uri):


### PR DESCRIPTION
This bug was preventing the Kyoto/Yahoo data from actually becoming part of the ConceptNet build. A related bug, where the test data didn't have the same header line, was making it look like it was.