### PR TITLE
Packaging related to publishing 5.7 raw data

### DIFF
--- a/DATA-CREDITS.md
+++ b/DATA-CREDITS.md
@@ -46,6 +46,8 @@ ConceptNet has been developed by:
   - Tilburg University
   - Nihon Unisys Labs
   - Dentsu Inc.
+  - Kyoto University
+  - Yahoo Research Japan
 
 * Luminoso Technologies, Inc.
 
@@ -71,7 +73,7 @@ order of appearance:
 * Robyn Speer
 * Ken Arnold
 * Yen-Ling Kuo
-
+* Naoki Otani
 
 ## Licenses for included resources
 

--- a/Snakefile
+++ b/Snakefile
@@ -69,7 +69,7 @@ PROPAGATE_SHARDS = 6
 # that will mainly be used to find more information about those terms.
 
 
-RAW_DATA_URL = "https://zenodo.org/record/1165009/files/conceptnet-raw-data-5.7.zip"
+RAW_DATA_URL = "https://zenodo.org/record/2579347/files/conceptnet-raw-data-5.7.zip"
 PRECOMPUTED_DATA_PATH = "/precomputed-data/2016"
 PRECOMPUTED_DATA_URL = "https://conceptnet.s3.amazonaws.com" + PRECOMPUTED_DATA_PATH
 PRECOMPUTED_S3_UPLOAD = "s3://conceptnet" + PRECOMPUTED_DATA_PATH


### PR DESCRIPTION
The new data is on Zenodo (https://zenodo.org/record/2579347) and I've updated the Snakefile and the credits accordingly.