### PR TITLE
Memory consumption

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -56,8 +56,9 @@ EMOJI_LANGUAGES = [
 # Increment this number when we incompatibly change the parser
 WIKT_PARSER_VERSION = "2"
 
+CONVERT_SHARDS = 6
 RETROFIT_SHARDS = 6
-PROPAGATE_SHARDS = 6
+PROPAGATE_SHARDS = 12
 
 # Dataset filenames
 # =================
@@ -565,7 +566,7 @@ rule assoc_uniq:
 rule reduce_assoc:
     input:
         DATA + "/assoc/assoc.csv",
-        expand(DATA + "/vectors/{name}.h5", name=INPUT_EMBEDDINGS)
+        expand(DATA + "/vectors/{name}-converted.h5", name=INPUT_EMBEDDINGS)
     output:
         DATA + "/assoc/reduced.csv"
     shell:
@@ -579,91 +580,113 @@ rule convert_word2vec:
         DATA + "/raw/vectors/GoogleNews-vectors-negative300.bin.gz",
         DATA + "/db/wiktionary.db"
     output:
-        DATA + "/vectors/w2v-google-news.h5"
+        temp(expand(DATA + "/vectors/w2v-google-news-converted.h5.shard{n}",
+                    n=range(CONVERT_SHARDS)))
     resources:
-        ram=24
+        ram=15
     run:
         single_input = input[0]
-        shell("CONCEPTNET_DATA=data cn5-vectors convert_word2vec -n {SOURCE_EMBEDDING_ROWS} {single_input} {output}")
+        output_prefix = output[0][:-len(".shard0")]
+        shell("CONCEPTNET_DATA=data cn5-vectors convert_word2vec -n {SOURCE_EMBEDDING_ROWS} --nshards {CONVERT_SHARDS} {single_input} {output_prefix}")
 
 rule convert_glove:
     input:
         DATA + "/raw/vectors/glove12.840B.300d.txt.gz",
         DATA + "/db/wiktionary.db"
     output:
-        DATA + "/vectors/glove12-840B.h5"
+        temp(expand(DATA + "/vectors/glove12-840B-converted.h5.shard{n}",
+                    n=range(CONVERT_SHARDS)))
     resources:
-        ram=24
+        ram=15
     run:
         single_input = input[0]
-        shell("CONCEPTNET_DATA=data cn5-vectors convert_glove -n {SOURCE_EMBEDDING_ROWS} {single_input} {output}")
+        output_prefix = output[0][:-len(".shard0")]
+        shell("CONCEPTNET_DATA=data cn5-vectors convert_glove -n {SOURCE_EMBEDDING_ROWS} --nshards {CONVERT_SHARDS} {single_input} {output_prefix}")
 
 rule convert_fasttext_crawl:
     input:
         DATA + "/raw/vectors/crawl-300d-2M.vec.gz",
         DATA + "/db/wiktionary.db"
     output:
-        DATA + "/vectors/crawl-300d-2M.h5"
+        temp(expand(DATA + "/vectors/crawl-300d-2M-converted.h5.shard{n}",
+                    n=range(CONVERT_SHARDS)))
     resources:
-        ram=24
+        ram=15
     run:
         single_input = input[0]
-        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {single_input} {output}")
+        output_prefix = output[0][:-len(".shard0")]
+        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} --nshards {CONVERT_SHARDS} {single_input} {output_prefix}")
 
 rule convert_fasttext:
     input:
         DATA + "/raw/vectors/fasttext-wiki-{lang}.vec.gz",
         DATA + "/db/wiktionary.db"
     output:
-        DATA + "/vectors/fasttext-wiki-{lang}.h5"
+        temp(expand(DATA + "/vectors/fasttext-wiki-{{lang}}-converted.h5.shard{n}",
+                    n=range(CONVERT_SHARDS)))
     resources:
-        ram=24
+        ram=15
     run:
         single_input = input[0]
-        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} -l {wildcards.lang} {single_input} {output}")
+        output_prefix = output[0][:-len(".shard0")]
+        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} -l {wildcards.lang} --nshards {CONVERT_SHARDS} {single_input} {output_prefix}")
 
 rule convert_lexvec:
     input:
         DATA + "/raw/vectors/lexvec.commoncrawl.300d.W+C.pos.vectors.gz",
         DATA + "/db/wiktionary.db"
     output:
-        DATA + "/vectors/lexvec-commoncrawl.h5"
+        temp(expand(DATA + "/vectors/lexvec-commoncrawl-converted.h5.shard{n}",
+                    n=range(CONVERT_SHARDS)))
     resources:
-        ram=24
+        ram=15
     run:
         single_input = input[0]
-        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} {single_input} {output}")
+        output_prefix = output[0][:-len(".shard0")]
+        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {SOURCE_EMBEDDING_ROWS} --nshards {CONVERT_SHARDS} {single_input} {output_prefix}")
 
 rule convert_opensubtitles_ft:
     input:
         DATA + "/raw/vectors/ft-opensubtitles.vec.gz",
         DATA + "/db/wiktionary.db"
     output:
-        DATA + "/vectors/fasttext-opensubtitles.h5"
+        temp(expand(DATA + "/vectors/fasttext-opensubtitles-converted.h5.shard{n}",
+                    n=range(CONVERT_SHARDS)))
     resources:
-        ram=24
+        ram=15
     run:
         single_input = input[0]
-        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {MULTILINGUAL_SOURCE_EMBEDDING_ROWS} {single_input} {output}")
+        output_prefix = output[0][:-len(".shard0")]
+        shell("CONCEPTNET_DATA=data cn5-vectors convert_fasttext -n {MULTILINGUAL_SOURCE_EMBEDDING_ROWS} --nshards {CONVERT_SHARDS} {single_input} {output_prefix}")
 
 rule convert_polyglot:
     input:
         DATA + "/raw/vectors/polyglot-{language}.pkl",
         DATA + "/db/wiktionary.db"
     output:
-        DATA + "/vectors/polyglot-{language}.h5"
+        DATA + "/vectors/polyglot-{language}-converted.h5"
     run:
         single_input = input[0]
         shell("CONCEPTNET_DATA=data cn5-vectors convert_polyglot -l {wildcards.language} {single_input} {output}")
 
+rule join_convert:
+    input:
+        expand(DATA + "/vectors/{{name}}-converted.h5.shard{n}", n=range(CONVERT_SHARDS))
+    output:
+        DATA + "/vectors/{name}-converted.h5"
+    resources:
+        ram=15
+    shell:
+        "cn5-vectors join_shard_files -n {CONVERT_SHARDS} {output}"
+
 rule retrofit:
     input:
-        DATA + "/vectors/{name}.h5",
+        DATA + "/vectors/{name}-converted.h5",
         DATA + "/assoc/reduced.csv"
     output:
         temp(expand(DATA + "/vectors/{{name}}-retrofit.h5.shard{n}", n=range(RETROFIT_SHARDS)))
     resources:
-        ram=24
+        ram=15
     shell:
         "cn5-vectors retrofit -n {RETROFIT_SHARDS} {input} {DATA}/vectors/{wildcards.name}-retrofit.h5"
 
@@ -673,7 +696,7 @@ rule join_retrofit:
     output:
         DATA + "/vectors/{name}-retrofit.h5"
     resources:
-        ram=24
+        ram=15
     shell:
         "cn5-vectors join_shard_files -n {RETROFIT_SHARDS} {output}"
 
@@ -684,7 +707,7 @@ rule merge_intersect:
         DATA + "/vectors/numberbatch-retrofitted.h5",
         DATA + "/vectors/intersection-projection.h5"
     resources:
-        ram=24
+        ram=15
     shell:
         "cn5-vectors intersect {input} {output}"
 
@@ -695,7 +718,7 @@ rule propagate:
     output:
         temp(expand(DATA + "/vectors/numberbatch-biased.h5.shard{n}", n=range(PROPAGATE_SHARDS)))
     resources:
-        ram=24
+        ram=15
     shell:
         "cn5-vectors propagate -n {PROPAGATE_SHARDS} {input} {DATA}/vectors/numberbatch-biased.h5"
 
@@ -705,7 +728,7 @@ rule join_propagate:
     output:
         DATA + "/vectors/numberbatch-biased.h5"
     resources:
-        ram=24
+        ram=15
     shell:
         "cn5-vectors join_shard_files -n {PROPAGATE_SHARDS} --sort {output}"
 
@@ -715,14 +738,14 @@ rule debias:
     output:
         DATA + "/vectors/numberbatch.h5"
     resources:
-        ram=30
+        ram=15
     shell:
         "cn5-vectors debias {input} {output}"
 
 rule miniaturize:
     input:
         DATA + "/vectors/numberbatch-biased.h5",
-        DATA + "/vectors/w2v-google-news.h5"
+        DATA + "/vectors/w2v-google-news-converted.h5"
     output:
         DATA + "/vectors/mini.h5"
     resources:
@@ -786,7 +809,7 @@ rule compare_embeddings:
     input:
         DATA + "/raw/vectors/GoogleNews-vectors-negative300.bin.gz",
         DATA + "/raw/vectors/glove12.840B.300d.txt.gz",
-        DATA + "/vectors/glove12-840B.h5",
+        DATA + "/vectors/glove12-840B-converted.h5",
         DATA + "/raw/vectors/fasttext-wiki-en.vec.gz",
         DATA + "/vectors/numberbatch-biased.h5",
         DATA + "/vectors/numberbatch.h5",

--- a/Snakefile
+++ b/Snakefile
@@ -58,7 +58,7 @@ WIKT_PARSER_VERSION = "2"
 
 CONVERT_SHARDS = 6
 RETROFIT_SHARDS = 6
-PROPAGATE_SHARDS = 12
+PROPAGATE_SHARDS = 10
 
 # Dataset filenames
 # =================

--- a/conceptnet5/builders/reduce_assoc.py
+++ b/conceptnet5/builders/reduce_assoc.py
@@ -181,8 +181,8 @@ def read_embedding_vocabularies(filenames):
     """
     result = pd.Index([])
     for filename in filenames:
-        vectors = load_hdf(filename)
-        result = result.union(vectors.index)
+        vectors_index = load_hdf(filename, index_only=True)
+        result = result.union(vectors_index)
     return result
 
 

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -85,8 +85,9 @@ def run_retrofit(
 @click.argument('glove_filename', type=click.Path(readable=True, dir_okay=False))
 @click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
 @click.option('--nrows', '-n', default=500000)
-def run_convert_glove(glove_filename, output_filename, nrows=500000):
-    convert_glove(glove_filename, output_filename, nrows)
+@click.option('--nshards', default=6)
+def run_convert_glove(glove_filename, output_filename, nrows=500000, nshards=6):
+    convert_glove(glove_filename, output_filename, nrows, nshards=nshards)
 
 
 @cli.command(name='convert_fasttext')
@@ -94,26 +95,35 @@ def run_convert_glove(glove_filename, output_filename, nrows=500000):
 @click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
 @click.option('--nrows', '-n', default=500000)
 @click.option('--language', '-l', default='en')
+@click.option('--nshards', default=6)
 def run_convert_fasttext(
-    fasttext_filename, output_filename, nrows=500000, language='en'
+    fasttext_filename, output_filename, nrows=500000, language='en', nshards=6
 ):
-    convert_fasttext(fasttext_filename, output_filename, nrows=nrows, language=language)
+    convert_fasttext(
+        fasttext_filename,
+        output_filename,
+        nrows=nrows,
+        language=language,
+        nshards=nshards,
+    )
 
 
 @cli.command(name='convert_word2vec')
 @click.argument('word2vec_filename', type=click.Path(readable=True, dir_okay=False))
 @click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
 @click.option('--nrows', '-n', default=500000)
-def run_convert_word2vec(word2vec_filename, output_filename, nrows=500000):
-    convert_word2vec(word2vec_filename, output_filename, nrows)
+@click.option('--nshards', default=6)
+def run_convert_word2vec(word2vec_filename, output_filename, nrows=500000, nshards=6):
+    convert_word2vec(word2vec_filename, output_filename, nrows, nshards=nshards)
 
 
 @cli.command(name='convert_polyglot')
 @click.argument('polyglot_filename', type=click.Path(readable=True, dir_okay=False))
 @click.argument('output_filename', type=click.Path(writable=True, dir_okay=False))
 @click.option('--language', '-l')
-def run_convert_polyglot(polyglot_filename, output_filename, language):
-    convert_polyglot(polyglot_filename, output_filename, language)
+@click.option('--nshards', default=6)
+def run_convert_polyglot(polyglot_filename, output_filename, language, nshards=6):
+    convert_polyglot(polyglot_filename, output_filename, language, nshards=nshards)
 
 
 @cli.command(name='intersect')
@@ -246,7 +256,7 @@ def run_compare_embeddings(input_filenames, output_filename, run_analogies):
         input_filenames, subset='all', run_analogies=run_analogies
     )
     print(results)
-    save_hdf(results, output_filename)
+    save_hdf(results, output_filename, format='mat')
 
 
 @cli.command(name='comparison_graph')
@@ -280,11 +290,8 @@ def run_miniaturize(input_filename, extra_vocab_filename, output_filename, k):
     """
     Save a smaller version of a frame, which includes frequent terms and phrases.
     """
-    frame = load_hdf(input_filename)
-    other_frame = load_hdf(extra_vocab_filename)
-    other_vocab = list(other_frame.index)
-    del other_frame
-    mini = miniaturize(frame, other_vocab=other_vocab, k=k)
+    other_vocab = list(load_hdf(extra_vocab_filename, index_only=True))
+    mini = miniaturize(input_filename, other_vocab=other_vocab, k=k)
     save_hdf(mini, output_filename)
 
 

--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -138,7 +138,7 @@ def run_intersect(input_filenames, output_filename, projection_filename):
     """
     intersected, projection = merge_intersect(input_filenames)
     save_hdf(intersected, output_filename)
-    save_hdf(projection, projection_filename)
+    save_hdf(projection, projection_filename, format='mat')
 
 
 @cli.command(name='debias')

--- a/conceptnet5/vectors/evaluation/compare.py
+++ b/conceptnet5/vectors/evaluation/compare.py
@@ -44,8 +44,9 @@ def compare_embeddings(filenames, subset='dev', run_analogies=False):
             frame_results.append(analogy_results)
 
         results.append(pd.concat(frame_results, axis=0))
+        del frame
     result = pd.concat(results, keys=filenames)
-    save_hdf(result, '/tmp/numberbatch-comparison.h5')
+    save_hdf(result, '/tmp/numberbatch-comparison.h5', format='mat')
     return result
 
 
@@ -74,7 +75,7 @@ def graph_comparison(table_filename, out_filename):
             'data/raw/vectors/GoogleNews-vectors-negative300.bin.gz',
         ),
         ('GloVe 1.2 840B', 'data/raw/vectors/glove12.840B.300d.txt.gz'),
-        ('GloVe renormalized', 'data/vectors/glove12-840B.h5'),
+        ('GloVe renormalized', 'data/vectors/glove12-840B-converted.h5'),
         ('fastText enWP (without OOV)', 'data/raw/vectors/fasttext-wiki-en.vec.gz'),
         # ('ConceptNet Numberbatch biased', 'data/vectors/numberbatch-biased.h5'),
         ('ConceptNet Numberbatch', 'data/vectors/numberbatch.h5'),

--- a/conceptnet5/vectors/formats.py
+++ b/conceptnet5/vectors/formats.py
@@ -1,32 +1,100 @@
+import contextlib
 import gzip
 import pickle
 import struct
+import tables
 
 import numpy as np
 import pandas as pd
 
 from ordered_set import OrderedSet
 
-from .transforms import l1_normalize_columns, l2_normalize_rows, standardize_row_labels
+from .transforms import l1_normalize_columns, standardize_row_labels
 
 
-def load_hdf(filename):
+def load_hdf(filename, index_only=False, start_row=0, end_row=None):
     """
     Load a semantic vector space from an HDF5 file.
 
     HDF5 is a complex format that can contain many instances of different kinds
-    of data. The convention we use is that the file contains one labeled
-    matrix, named "mat".
+    of data. We store files in one of two formats:  either the file contains a
+    single group named "data", wich in turn contains two arrays named "index"
+    and "vectors", or the file contains a single group named "mat" (under which
+    various data is saved by pandas to_hdf).
+
+    If the optional argument index_only (default False) is set to True only the
+    index (vocabulary) of the file will be returned.
+
+    Optional arguments start_row and end_row may be given, in which case only
+    rows in the range from the given start to one before the given end will
+    be returned; this enables processing a large file in "horizontal" shards.
+    If not specified, the start row defaults to 0 and the end to one past the
+    final row of the file.
+
+    If any of these optional arguments are specified and the file is in "data"
+    format, only the requested data will be read from disk (which can save
+    significant memory).  Files in "mat" format must be read in their entirety
+    (though they still support the optional arguments; after reading only the
+    requested data is returned) but allow storage of column labels.
     """
-    return pd.read_hdf(filename, 'mat', encoding='utf-8')
+    with contextlib.closing(tables.open_file(filename, mode="r")) as file:
+        if hasattr(file.root, "data"):
+            # Handle a new-style file.
+            if end_row is None:
+                end_row = file.root.data.vectors.nrows
+            index = pd.Index(
+                array.tobytes().decode("utf-8")
+                for array in file.root.data.index.iterrows(
+                    start=start_row, stop=end_row
+                )
+            )
+            if index_only:
+                return index
+            else:
+                vectors = file.root.data.vectors.read(
+                    start=start_row, stop=end_row
+                )
+                frame = pd.DataFrame(index=index, data=vectors)
+                return frame
+
+    # Handle old-style files.
+    frame = pd.read_hdf(filename, "mat", encoding="utf-8")
+    if end_row is None:
+        end_row = len(frame)
+    if index_only:
+        return frame.index[start_row:end_row]
+    else:
+        return frame.iloc[start_row:end_row]
 
 
-def save_hdf(table, filename):
+def save_hdf(table, filename, format="data"):
     """
-    Save a semantic vector space into an HDF5 file, following the convention
-    of storing it as a labeled matrix named 'mat'.
+    Save a semantic vector space into an HDF5 file.  If the optional argument
+    "format" has value "data", the space will be stored under a group named
+    "data", in two arrays named "index" and "vectors".  This format allows
+    reading a subset of the rows of the space if desired.  Otherwise the space
+    will be stored (using to_hdf) under a group named "mat".  This format does
+    not allow partial reads (more precisely, load_hdf can be called on such
+    files to read a subset of the rows, but the entire file will be read into
+    memory before the subset is returned) but permits column labels to be
+    stored.
     """
-    return table.to_hdf(filename, 'mat', mode='w', encoding='utf-8')
+    if format == "data":
+        with contextlib.closing(tables.open_file(filename, mode="w")) as file:
+            file.create_group("/", "data", "Index and vector data.")
+            file.create_array(
+                file.root.data, name="vectors", byteorder="little", obj=table.values
+            )
+            index = file.create_vlarray(
+                file.root.data,
+                name="index",
+                byteorder="little",
+                atom=tables.UInt8Atom(shape=()),
+            )
+            for term in table.index:
+                index.append(np.frombuffer(term.encode("utf-8"), np.uint8))
+    else:
+        table.to_hdf(filename, "mat", mode="w", encoding="utf-8")
 
 
 def save_labels(table, vocab_filename):
@@ -46,8 +114,8 @@ def vec_to_text_line(label, vec):
     """
     Output a labeled vector as a line in a fastText-style text format.
     """
-    cells = [label] + ['%4.4f' % val for val in vec]
-    return ' '.join(cells)
+    cells = [label] + ["%4.4f" % val for val in vec]
+    return " ".join(cells)
 
 
 def export_text(frame, filename, filter_language=None):
@@ -59,61 +127,86 @@ def export_text(frame, filename, filter_language=None):
     vectors = frame.values
     index = frame.index
     if filter_language is not None:
-        start_idx = index.get_loc('/c/%s/#' % filter_language, method='bfill')
+        start_idx = index.get_loc("/c/%s/#" % filter_language, method="bfill")
         try:
-            end_idx = index.get_loc('/c/%s0' % filter_language, method='bfill')
+            end_idx = index.get_loc("/c/%s0" % filter_language, method="bfill")
         except KeyError:
             end_idx = frame.shape[0]
         frame = frame.iloc[start_idx:end_idx]
         vectors = frame.values
         index = frame.index
 
-    with gzip.open(filename, 'wt') as out:
+    with gzip.open(filename, "wt") as out:
         dims = "%s %s" % frame.shape
         print(dims, file=out)
         for i in range(frame.shape[0]):
             label = index[i]
             if filter_language is not None:
-                label = label.split('/', 3)[-1]
+                label = label.split("/", 3)[-1]
             vec = vectors[i]
             print(vec_to_text_line(label, vec), file=out)
 
 
-def convert_glove(glove_filename, output_filename, nrows):
+def convert_glove(glove_filename, output_filename, nrows, nshards=6):
     """
-    Convert GloVe data from a gzipped text file to an HDF5 dataframe.
+    Convert GloVe data from a gzipped text file to shards in HDF5 dataframes.
     """
-    glove_raw = load_glove(glove_filename, nrows)
-    glove_std = standardize_row_labels(glove_raw, forms=False)
-    del glove_raw
-    glove_normal = l2_normalize_rows(l1_normalize_columns(glove_std))
-    del glove_std
-    save_hdf(glove_normal, output_filename)
+    ncols = len(load_glove(glove_filename, max_rows=1).columns)
+    shard_length = (ncols + nshards - 1) // nshards
+    for i_shard in range(nshards):
+        start_column = i_shard * shard_length
+        end_column = min(start_column + shard_length, ncols)
+        shard_filename = output_filename + ".shard{}".format(i_shard)
+        glove_raw = load_glove(
+            glove_filename, nrows, start_column=start_column, end_column=end_column
+        )
+        glove_std = standardize_row_labels(glove_raw, forms=False)
+        del glove_raw
+        glove_normal = l1_normalize_columns(glove_std)
+        save_hdf(glove_normal, shard_filename)
 
 
-def convert_fasttext(fasttext_filename, output_filename, nrows, language):
+def convert_fasttext(fasttext_filename, output_filename, nrows, language, nshards=6):
     """
-    Convert FastText data from a gzipped text file to an HDF5 dataframe.
+    Convert FastText data from a gzipped text file to shards in HDF5 dataframes.
     """
-    ft_raw = load_fasttext(fasttext_filename, nrows)
-    ft_std = standardize_row_labels(ft_raw, forms=False, language=language)
-    del ft_raw
-    ft_normal = l2_normalize_rows(l1_normalize_columns(ft_std))
-    del ft_std
-    save_hdf(ft_normal, output_filename)
+    ncols = len(load_fasttext(fasttext_filename, max_rows=1).columns)
+    shard_length = (ncols + nshards - 1) // nshards
+    for i_shard in range(nshards):
+        start_column = i_shard * shard_length
+        end_column = min(start_column + shard_length, ncols)
+        shard_filename = output_filename + ".shard{}".format(i_shard)
+        ft_raw = load_fasttext(
+            fasttext_filename, nrows, start_column=start_column, end_column=end_column
+        )
+        ft_std = standardize_row_labels(ft_raw, forms=False, language=language)
+        del ft_raw
+        ft_normal = l1_normalize_columns(ft_std)
+        del ft_std
+        save_hdf(ft_normal, shard_filename)
 
 
-def convert_word2vec(word2vec_filename, output_filename, nrows, language='en'):
+def convert_word2vec(
+    word2vec_filename, output_filename, nrows, language="en", nshards=6
+):
     """
-    Convert word2vec data from its gzipped binary format to an HDF5
-    dataframe.
+    Convert word2vec data from its gzipped binary format to shards in HDF5
+    dataframes.
     """
-    w2v_raw = load_word2vec_bin(word2vec_filename, nrows)
-    w2v_std = standardize_row_labels(w2v_raw, forms=False, language=language)
-    del w2v_raw
-    w2v_normal = l2_normalize_rows(l1_normalize_columns(w2v_std))
-    del w2v_std
-    save_hdf(w2v_normal, output_filename)
+    ncols = len(load_word2vec_bin(word2vec_filename, nrows=1).columns)
+    shard_length = (ncols + nshards - 1) // nshards
+    for i_shard in range(nshards):
+        start_column = i_shard * shard_length
+        end_column = min(start_column + shard_length, ncols)
+        shard_filename = output_filename + ".shard{}".format(i_shard)
+        w2v_raw = load_word2vec_bin(
+            word2vec_filename, nrows, start_column=start_column, end_column=end_column
+        )
+        w2v_std = standardize_row_labels(w2v_raw, forms=False, language=language)
+        del w2v_raw
+        w2v_normal = l1_normalize_columns(w2v_std)
+        del w2v_std
+        save_hdf(w2v_normal, shard_filename)
 
 
 def convert_polyglot(polyglot_filename, output_filename, language):
@@ -126,7 +219,7 @@ def convert_polyglot(polyglot_filename, output_filename, language):
     save_hdf(pg_std, output_filename)
 
 
-def load_glove(filename, max_rows=1000000):
+def load_glove(filename, max_rows=1000000, start_column=0, end_column=None):
     """
     Load a DataFrame from the GloVe text format, which is the same as the
     fastText format except it doesn't tell you up front how many rows and
@@ -134,68 +227,92 @@ def load_glove(filename, max_rows=1000000):
     """
     arr = None
     label_list = []
-    with gzip.open(filename, 'rt') as infile:
+    with gzip.open(filename, "rt") as infile:
         for i, line in enumerate(infile):
             if i >= max_rows:
                 break
-            items = line.rstrip().split(' ')
+            items = line.rstrip().split(" ")
             label_list.append(items[0])
             if arr is None:
                 ncols = len(items) - 1
-                arr = np.zeros((max_rows, ncols), 'f')
+                if end_column is None:
+                    end_column = ncols
+                if not 0 <= start_column <= ncols:
+                    raise ValueError(
+                        "Invalid start column {} (out of {}).".format(
+                            start_column, ncols
+                        )
+                    )
+                if end_column - start_column > ncols:
+                    end_column = ncols
+                ncols = end_column - start_column
+                arr = np.zeros((max_rows, ncols), "f")
             values = [float(x) for x in items[1:]]
-            arr[i] = values
+            arr[i] = values[start_column:end_column]
 
     if len(label_list) < max_rows:
         arr = arr[: len(label_list)]
-    return pd.DataFrame(arr, index=label_list, dtype='f')
+    return pd.DataFrame(
+        arr, index=label_list, dtype="f", columns=list(range(start_column, end_column))
+    )
 
 
-def load_fasttext(filename, max_rows=1000000):
+def load_fasttext(filename, max_rows=1000000, start_column=0, end_column=None):
     """
     Load a DataFrame from the fastText text format.
     """
     arr = None
     label_list = []
-    with gzip.open(filename, 'rt') as infile:
+    with gzip.open(filename, "rt") as infile:
         nrows_str, ncols_str = infile.readline().rstrip().split()
 
         nrows = min(int(nrows_str), max_rows)
         ncols = int(ncols_str)
-        arr = np.zeros((nrows, ncols), dtype='f')
+        if end_column is None:
+            end_column = ncols
+        if not 0 <= start_column <= ncols:
+            raise ValueError(
+                "Invalid start column {} (out of {}).".format(start_column, ncols)
+            )
+        if end_column - start_column > ncols:
+            end_column = ncols
+        ncols = end_column - start_column
+        arr = np.zeros((nrows, ncols), dtype="f")
         for line in infile:
             if len(label_list) >= nrows:
                 break
-            items = line.rstrip().split(' ')
+            items = line.rstrip().split(" ")
             label = items[0]
-            if label != '</s>':
+            if label != "</s>":
                 values = [float(x) for x in items[1:]]
-                arr[len(label_list)] = values
+                arr[len(label_list)] = values[start_column:end_column]
                 label_list.append(label)
 
     if len(label_list) < max_rows:
         arr = arr[: len(label_list)]
-    return pd.DataFrame(arr, index=label_list, dtype='f')
+    return pd.DataFrame(
+        arr, index=label_list, dtype="f", columns=list(range(start_column, end_column))
+    )
 
 
 def _read_until_space(file):
     chars = []
     while True:
         newchar = file.read(1)
-        if newchar == b'' or newchar == b' ':
+        if newchar == b"" or newchar == b" ":
             break
         chars.append(newchar[0])
-    return bytes(chars).decode('utf-8', 'replace')
+    return bytes(chars).decode("utf-8", "replace")
 
 
 def _read_vec(file, ndims):
-    fmt = 'f' * ndims
+    fmt = "f" * ndims
     bytes_in = file.read(4 * ndims)
     values = list(struct.unpack(fmt, bytes_in))
     return np.array(values)
 
 
-def load_word2vec_bin(filename, nrows):
+def load_word2vec_bin(filename, nrows, start_column=0, end_column=None):
     """
     Load a DataFrame from word2vec's binary format. (word2vec's text format
     should be the same as fastText's, but it's less efficient to load the
@@ -203,33 +320,44 @@ def load_word2vec_bin(filename, nrows):
     """
     label_list = []
     arr = None
-    with gzip.open(filename, 'rb') as infile:
+    with gzip.open(filename, "rb") as infile:
         header = infile.readline().rstrip()
         nrows_str, ncols_str = header.split()
         nrows = min(int(nrows_str), nrows)
         ncols = int(ncols_str)
-        arr = np.zeros((nrows, ncols), dtype='f')
+        if end_column is None:
+            end_column = ncols
+        if not 0 <= start_column <= ncols:
+            raise ValueError(
+                "Invalid start column {} (out of {}).".format(start_column, ncols)
+            )
+        if end_column - start_column > ncols:
+            end_column = ncols
+        requested_ncols = end_column - start_column
+        arr = np.zeros((nrows, requested_ncols), dtype="f")
         while len(label_list) < nrows:
             label = _read_until_space(infile)
             vec = _read_vec(infile, ncols)
-            if label == '</s>':
+            if label == "</s>":
                 # Skip the word2vec sentence boundary marker, which will not
                 # correspond to anything in other data
                 continue
             idx = len(label_list)
-            arr[idx] = vec
+            arr[idx] = vec[start_column:end_column]
             label_list.append(label)
 
-    return pd.DataFrame(arr, index=label_list, dtype='f')
+    return pd.DataFrame(
+        arr, index=label_list, dtype="f", columns=list(range(start_column, end_column))
+    )
 
 
 def load_polyglot(filename):
     """
     Load a pickled matrix from the Polyglot format.
     """
-    labels, arr = pickle.load(open(filename, 'rb'), encoding='bytes')
+    labels, arr = pickle.load(open(filename, "rb"), encoding="bytes")
     label_list = list(labels)
-    return pd.DataFrame(arr, index=label_list, dtype='f')
+    return pd.DataFrame(arr, index=label_list, dtype="f")
 
 
 def load_labels_and_npy(label_file, npy_file):
@@ -237,9 +365,9 @@ def load_labels_and_npy(label_file, npy_file):
     Load a semantic vector space from two files: a NumPy .npy file of the matrix,
     and a text file with one label per line.
     """
-    label_list = [line.rstrip('\n') for line in open(label_file, encoding='utf-8')]
+    label_list = [line.rstrip("\n") for line in open(label_file, encoding="utf-8")]
     arr = np.load(npy_file)
-    return pd.DataFrame(arr, index=label_list, dtype='f')
+    return pd.DataFrame(arr, index=label_list, dtype="f")
 
 
 def load_labels_as_index(label_filename):
@@ -247,7 +375,7 @@ def load_labels_as_index(label_filename):
     Load a set of labels (with no attached vectors) from a text file, and
     represent them in a pandas Index.
     """
-    labels = [line.rstrip('\n') for line in open(label_filename, encoding='utf-8')]
+    labels = [line.rstrip("\n") for line in open(label_filename, encoding="utf-8")]
     return pd.Index(labels)
 
 
@@ -255,7 +383,7 @@ def save_index_as_labels(index, label_filename):
     """
     Save a pandas Index as a text file of labels.
     """
-    with open(label_filename, 'w', encoding='utf-8') as out:
+    with open(label_filename, "w", encoding="utf-8") as out:
         for label in index:
             print(label, file=out)
 
@@ -264,7 +392,7 @@ def save_ordered_set(oset, filename):
     """
     Save an OrderedSet object as a text file of words.
     """
-    with open(filename, 'w', encoding='utf-8') as out:
+    with open(filename, "w", encoding="utf-8") as out:
         for word in oset:
             print(word, file=out)
 
@@ -275,6 +403,6 @@ def load_ordered_set(filename):
     represent them in an OrderedSet object.
     """
     oset = OrderedSet()
-    for line in open(filename, encoding='utf-8'):
-        oset.append(line.rstrip('\n'))
+    for line in open(filename, encoding="utf-8"):
+        oset.append(line.rstrip("\n"))
     return oset

--- a/conceptnet5/vectors/miniaturize.py
+++ b/conceptnet5/vectors/miniaturize.py
@@ -6,6 +6,7 @@ from conceptnet5.languages import CORE_LANGUAGES
 from conceptnet5.uri import split_uri
 
 from .debias import de_bias_frame
+from .formats import load_hdf
 
 
 def term_freq(term):
@@ -27,7 +28,7 @@ def term_freq(term):
         return 0.
 
 
-def miniaturize(frame, other_vocab=None, k=300, debias=True):
+def miniaturize(input_filename, other_vocab=None, k=300, debias=True):
     """
     Produce a small matrix with good coverage of English and reasonable
     coverage of the other 'core languages' in ConceptNet. Three things that
@@ -47,24 +48,43 @@ def miniaturize(frame, other_vocab=None, k=300, debias=True):
     #
     # Non-English languages use terms with frequency 1e-6 or greater, because
     # only that much of the list has been loaded.
+    frame_index = load_hdf(input_filename, index_only=True)
     vocab1 = [
-        term for term in frame.index if '_' not in term and term_freq(term) >= 1e-8
+        term for term in frame_index if '_' not in term and term_freq(term) >= 1e-8
     ]
     vocab_set = set(vocab1)
     if other_vocab is not None:
         extra_vocab = [
             term
             for term in other_vocab
-            if '_' in term and term in frame.index and term not in vocab_set
+            if '_' in term and term in frame_index and term not in vocab_set
         ]
         extra_vocab = extra_vocab[:20000]
     else:
         extra_vocab = []
 
     vocab = vocab1 + extra_vocab
-    smaller = frame.loc[vocab]
+    del vocab1, extra_vocab, vocab_set
+
+    # We'd like to set smaller = load_hdf(input_filename).loc[vocab].values,
+    # but that could run out of memory.  So we process the frame in shards.
+    smaller = None
+    n_rows = len(vocab)
+    shard_size = int(250e6)  # about one (decimal) gigabyte of float32
+    n_shards = (n_rows + shard_size - 1) // shard_size
+    for i_shard in range(n_shards):
+        shard_start = i_shard * shard_size
+        shard_end = min(shard_start + shard_size, n_rows)
+        shard = load_hdf(input_filename, start_row=shard_start, end_row=shard_end)
+        if smaller is None:
+            n_cols = shard.values.shape[1]
+            smaller = np.empty(shape=(n_rows, n_cols), dtype=np.float32)
+        smaller[shard_start:shard_end, :] = shard.loc[
+            vocab[shard_start:shard_end]
+        ].values
+
     U, _S, _Vt = np.linalg.svd(smaller, full_matrices=False)
-    del smaller, _S, _Vt, vocab1, extra_vocab, vocab_set
+    del smaller, _S, _Vt
     redecomposed = pd.DataFrame(U[:, :k], index=vocab, dtype='f')
     del U, vocab
     if debias:

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -98,7 +98,7 @@ class VectorSpaceWrapper(object):
 
             self.k = self.frame.shape[1]
             self.small_k = 100
-            self.small_frame = self.frame.iloc[:, : self.small_k].copy()
+            self.small_frame = self.frame.iloc[:, : self.small_k]
         except OSError:
             raise MissingVectorSpace(
                 "Couldn't load the vector space %r. Do you need to build or "

--- a/conceptnet5/vectors/retrofit.py
+++ b/conceptnet5/vectors/retrofit.py
@@ -27,7 +27,7 @@ def sharded_retrofit(
     shard_width = frame_box[0].shape[1] // nshards
 
     for i in range(nshards):
-        temp_filename = output_filename + '.shard%d' % i
+        temp_filename = output_filename + ".shard%d" % i
         shard_from = shard_width * i
         shard_to = shard_from + shard_width
         if len(frame_box) == 0:
@@ -52,21 +52,30 @@ def sharded_retrofit(
 
 
 def join_shards(output_filename, nshards=6, sort=False):
-    joined_matrix = None
-    joined_labels = None
-    for i in range(nshards):
-        shard = load_hdf(output_filename + '.shard%d' % i)
-        nrows, ncols = shard.shape
-        if joined_matrix is None:
-            joined_matrix = np.zeros((nrows, ncols * nshards), dtype='f')
-            joined_labels = shard.index
-        joined_matrix[:, (ncols * i) : (ncols * (i + 1))] = shard.values
-        del shard
-
-    normalize(joined_matrix, axis=1, norm='l2', copy=False)
-    dframe = pd.DataFrame(joined_matrix, index=joined_labels)
+    assert nshards > 0
+    shard = load_hdf(output_filename + ".shard0")
+    nrows, ncols = shard.shape
     if sort:
-        dframe.sort_index(inplace=True)
+        # Sort the index and save the permutation bringing it into
+        # ascending alphabetical order, _before_ allocating a big chunk
+        # of memory for the joined vector values, to keep the maximum
+        # memory consumption down.
+        joined_labels, permutation = shard.index.sort_values(return_indexer=True)
+    else:
+        joined_labels = shard.index
+        permutation = np.arange(nrows)
+
+    joined_matrix = np.zeros((nrows, ncols * nshards), dtype="f")
+    joined_matrix[:, 0:ncols] = shard.values[permutation, :]
+    del shard
+
+    for i in range(1, nshards):
+        shard_values = load_hdf(output_filename + ".shard%d" % i).values
+        joined_matrix[:, (ncols * i) : (ncols * (i + 1))] = shard_values[permutation, :]
+        del shard_values
+
+    normalize(joined_matrix, axis=1, norm="l2", copy=False)
+    dframe = pd.DataFrame(joined_matrix, index=joined_labels)
     save_hdf(dframe, output_filename)
 
 
@@ -106,7 +115,7 @@ def retrofit(
     appropriately.
     """
     # Initialize a DataFrame with rows that we know
-    retroframe = pd.DataFrame(index=row_labels, columns=dense_frame.columns, dtype='f')
+    retroframe = pd.DataFrame(index=row_labels, columns=dense_frame.columns, dtype="f")
     retroframe.update(dense_frame)
 
     # orig_weights = 1 for known vectors, 0 for unknown vectors
@@ -124,7 +133,7 @@ def retrofit(
     vecs = orig_vecs
     for iteration in range(iterations):
         if verbosity >= 1:
-            print('Retrofitting: Iteration %s of %s' % (iteration + 1, iterations))
+            print("Retrofitting: Iteration %s of %s" % (iteration + 1, iterations))
 
         # Since the sparse weight matrix is row-stochastic and has self-loops,
         # pre-multiplication by it replaces each vector by a weighted average
@@ -198,7 +207,7 @@ def retrofit(
         )
         vecs[new_nonzero_indicators, :] /= total_neighbor_weights
     else:
-        print('Warning: cleanup iteration limit exceeded.')
+        print("Warning: cleanup iteration limit exceeded.")
 
     retroframe = pd.DataFrame(data=vecs, index=row_labels, columns=dense_frame.columns)
     return retroframe

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'snakemake', 'click', 'requests', 'ftfy', 'msgpack-python', 'numpy',
         'langcodes >= 1.4.1', 'wordfreq >= 2.0.1',
         'xmltodict >= 0.11.0, < 0.12.0', 'ordered_set', 'psycopg2-binary',
-        'marisa-trie'
+        'marisa-trie', 'tables >= 3.5.1'
     ],
     python_requires='>=3.5',
     license='Apache License 2.0',


### PR DESCRIPTION
This PR contains changes to reduce the RAM needed to build ConceptNet down to 15GB.  The main changes are additional sharding (e.g. the "convert" steps packaging input vector embeddings as hdf files are now done on shards, and the "propagate" step is done with a larger number of shards).  Also, a new internal format for hdf5 files is introduced, to allow reading the files in "horizontal" shards (i.e., it is possible to read a selected subset of the rows of a new-format file rather than the entire file).

Changes to the resulting vectors (as shown by cn5-vectors evaluate) are minimal.
