### PR TITLE
Fix malformed /related query

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -73,6 +73,11 @@ RAW_DATA_URL = "https://zenodo.org/record/2579347/files/conceptnet-raw-data-5.7.
 PRECOMPUTED_DATA_PATH = "/precomputed-data/2016"
 PRECOMPUTED_DATA_URL = "https://conceptnet.s3.amazonaws.com" + PRECOMPUTED_DATA_PATH
 PRECOMPUTED_S3_UPLOAD = "s3://conceptnet" + PRECOMPUTED_DATA_PATH
+
+# We need an external vocabulary to refer to when miniaturizing our set of
+# embeddings. In the normal case, this is the word2vec Google News vocabulary.
+# In the test build, we don't have that, we only have a cut-down version of GloVe,
+# so we'll switch it to that instead.
 MINI_VOCAB_SOURCE = "/vectors/w2v-google-news.h5"
 
 INPUT_EMBEDDINGS = [

--- a/Snakefile
+++ b/Snakefile
@@ -73,6 +73,7 @@ RAW_DATA_URL = "https://zenodo.org/record/2579347/files/conceptnet-raw-data-5.7.
 PRECOMPUTED_DATA_PATH = "/precomputed-data/2016"
 PRECOMPUTED_DATA_URL = "https://conceptnet.s3.amazonaws.com" + PRECOMPUTED_DATA_PATH
 PRECOMPUTED_S3_UPLOAD = "s3://conceptnet" + PRECOMPUTED_DATA_PATH
+MINI_VOCAB_SOURCE = "/vectors/w2v-google-news.h5"
 
 INPUT_EMBEDDINGS = [
     'crawl-300d-2M', 'w2v-google-news', 'glove12-840B', 'fasttext-opensubtitles'
@@ -96,6 +97,7 @@ if TESTMODE:
     RAW_DATA_URL = "/missing/data"
     PRECOMPUTED_DATA_URL = "/missing/data"
     EMOJI_LANGUAGES = ['en', 'en_001']
+    MINI_VOCAB_SOURCE = "/vectors/glove12-840B.h5"
 
 
 CORE_DATASET_NAMES = [
@@ -161,6 +163,7 @@ rule test:
         DATA + "/assertions/assertions.csv",
         DATA + "/psql/done",
         DATA + "/assoc/reduced.csv",
+        DATA + "/vectors/mini.h5",
         DATA + "/vectors/plain/numberbatch-en.txt.gz",
 
 
@@ -730,7 +733,7 @@ rule debias:
 rule miniaturize:
     input:
         DATA + "/vectors/numberbatch-biased.h5",
-        DATA + "/vectors/w2v-google-news.h5"
+        DATA + MINI_VOCAB_SOURCE
     output:
         DATA + "/vectors/mini.h5"
     resources:

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -122,7 +122,13 @@ class VectorSpaceWrapper(object):
 
     @staticmethod
     def _englishify(term):
+        """
+        Change the language of a /c/ term to English. If the input isn't a term,
+        return None.
+        """
         splits = split_uri(term)
+        if not term.startswith('/c/'):
+            return None
         if len(splits) > 2:
             englishified = '/c/en/' + splits[2]
             return englishified

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -188,7 +188,8 @@ class VectorSpaceWrapper(object):
                 prefix_weight = 0.01
                 if get_uri_language(term) != 'en':
                     englishified = self._englishify(term)
-                    expanded.append((englishified, prefix_weight))
+                    if englishified is not None:
+                        expanded.append((englishified, prefix_weight))
 
                 prefix_matches = self._match_prefix(term, prefix_weight)
                 expanded.extend(prefix_matches)

--- a/tests/small-build/test_api.py
+++ b/tests/small-build/test_api.py
@@ -5,7 +5,6 @@ from nose.tools import eq_
 def test_related_query():
     # Test that we can look up related terms
     result = api.query_related('/c/en/test', limit=3)
-    print(result)
     eq_(len(result['related']), 3)
 
 
@@ -13,6 +12,5 @@ def test_related_query_malformed():
     # Test that we fulfill a query for related terms to a nonsense URI, and
     # there are simply no results
     result = api.query_related('/c/en,test', limit=3)
-    print(result)
     eq_(len(result['related']), 0)
 

--- a/tests/small-build/test_api.py
+++ b/tests/small-build/test_api.py
@@ -1,0 +1,18 @@
+from conceptnet5 import api
+from nose.tools import eq_
+
+
+def test_related_query():
+    # Test that we can look up related terms
+    result = api.query_related('/c/en/test', limit=3)
+    print(result)
+    eq_(len(result['related']), 3)
+
+
+def test_related_query_malformed():
+    # Test that we fulfill a query for related terms to a nonsense URI, and
+    # there are simply no results
+    result = api.query_related('/c/en,test', limit=3)
+    print(result)
+    eq_(len(result['related']), 0)
+


### PR DESCRIPTION
Fixes the bug that caused a 500 error, at https://trello.com/c/84a6YUxu/751-bug-a-malformed-related-query-gives-a-500-error-instead-of-400, when given something that looks like a term but has too few URI components.

This PR also includes fixes that make it possible to test the /related API endpoint.