### PR TITLE
Changes to building and querying of embeddings

### DIFF
--- a/conceptnet5/api.py
+++ b/conceptnet5/api.py
@@ -3,10 +3,12 @@ This file defines the ConceptNet web API responses.
 """
 
 from conceptnet5.nodes import ld_node, standardized_concept_uri
+from conceptnet5.db.config import DB_NAME
+from conceptnet5.db.query import AssertionFinder
 from conceptnet5.vectors.query import VectorSpaceWrapper
 
 VECTORS = VectorSpaceWrapper()
-FINDER = VECTORS.finder
+FINDER = AssertionFinder(dbname=DB_NAME)
 CONTEXT = ["http://api.conceptnet.io/ld/conceptnet5.7/context.ld.json"]
 VALID_KEYS = ['rel', 'start', 'end', 'node', 'other', 'source', 'uri']
 

--- a/conceptnet5/db/query.py
+++ b/conceptnet5/db/query.py
@@ -132,7 +132,7 @@ def gin_jsonb_value(criteria, node_forward=True):
 
 class AssertionFinder(object):
     """
-    The object that interacts with the database to find ConcetNet assertions
+    The object that interacts with the database to find ConceptNet assertions
     (edges) matching certain criteria.
     """
 

--- a/conceptnet5/vectors/evaluation/wordsim.py
+++ b/conceptnet5/vectors/evaluation/wordsim.py
@@ -725,6 +725,7 @@ def evaluate_raw(frame, subset='dev', semeval_scope='global'):
     men_score = measure_correlation(spearmanr, frame, read_men3000(subset))
     rw_score = measure_correlation(spearmanr, frame, read_rw(subset))
     mturk_score = measure_correlation(spearmanr, frame, read_mturk())
+    simlex_score = measure_correlation(spearmanr, frame, read_simlex())
     gur350_score = measure_correlation(spearmanr, frame, read_gurevych('350'))
     zg222_score = measure_correlation(spearmanr, frame, read_gurevych('222'))
     ws_score = measure_correlation(spearmanr, frame, read_ws353())
@@ -737,6 +738,7 @@ def evaluate_raw(frame, subset='dev', semeval_scope='global'):
     results.loc['men3000'] = men_score
     results.loc['rw'] = rw_score
     results.loc['mturk'] = mturk_score
+    results.loc['simlex'] = simlex_score
     results.loc['gur350-de'] = gur350_score
     results.loc['zg222-de'] = zg222_score
     results.loc['ws353'] = ws_score

--- a/conceptnet5/vectors/propagate.py
+++ b/conceptnet5/vectors/propagate.py
@@ -10,6 +10,7 @@ from scipy.sparse import diags
 
 from conceptnet5.builders.reduce_assoc import ConceptNetAssociationGraph
 from conceptnet5.uri import get_uri_language
+from conceptnet5.vectors import replace_numbers
 
 from .formats import load_hdf, save_hdf
 from .sparse_matrix_builder import SparseMatrixBuilder
@@ -30,6 +31,10 @@ class ConceptNetAssociationGraphForPropagation(ConceptNetAssociationGraph):
         In addition to the superclass's handling of a new edge,
         saves the edges as a set of (left, right) pairs.
         """
+        # Use URIs that have the additional standardization for vector-space labels,
+        # replacing sequences of digits with the # sign.
+        left = replace_numbers(left)
+        right = replace_numbers(right)
         super().add_edge(left, right, value, dataset, relation)
         self.edges.add((left, right))
         self.edges.add((right, left))  # save undirected edges

--- a/conceptnet5/vectors/query.py
+++ b/conceptnet5/vectors/query.py
@@ -149,7 +149,7 @@ class VectorSpaceWrapper(object):
             term = term[:-1]
         return results
 
-    def expand_terms(self, terms, limit_per_term=10, oov_vector=True):
+    def expand_terms(self, terms, oov_vector=True):
         """
         Given a list of weighted terms as (term, weight) tuples, if any of the terms
         are OOV, find approximations to those terms: the same term in English, or terms
@@ -179,18 +179,18 @@ class VectorSpaceWrapper(object):
                 (uri_prefix(term), weight / total_weight) for (term, weight) in expanded
             ]
 
-    def expanded_vector(self, terms, limit_per_term=10, oov_vector=True):
+    def expanded_vector(self, terms, oov_vector=True):
         """
         Given a list of weighted terms as (term, weight) tuples, make a vector
         representing information from:
 
         - The vectors for these terms
-        - The vectors for their neighbors in ConceptNet
+        - The vectors for equivalently spelled terms in the English vocabulary
         - The vectors for terms that share a sufficiently-long prefix with
           any terms in this list that are out-of-vocabulary
         """
         return weighted_average(
-            self.frame, self.expand_terms(terms, limit_per_term, oov_vector)
+            self.frame, self.expand_terms(terms, oov_vector)
         )
 
     def text_to_vector(self, language, text):
@@ -249,8 +249,8 @@ class VectorSpaceWrapper(object):
         - A single term
         - An existing vector
 
-        If the query contains 5 or fewer terms, it will be expanded to include
-        neighboring terms in ConceptNet.
+        If the query contains 5 or fewer terms, it will be expanded using the
+        out-of-vocab strategy.
         """
         self.load()
         vec = self.get_vector(query)

--- a/tests/small-build/test_propagate.py
+++ b/tests/small-build/test_propagate.py
@@ -85,6 +85,18 @@ def extract_positional_arg(mock_obj, call_number, position):
 _term_count = 0
 
 
+def _numbers_to_letters(num):
+    """
+    Write base-10 numbers using the alphabet 'qrstuvwxyz', so that they won't be
+    normalized away.
+    """
+    numstr = str(num)
+    for digit in '0123456789':
+        letter = chr(ord(digit) - ord('0') + ord('q'))
+        numstr = numstr.replace(digit, letter)
+    return numstr
+
+
 def make_term():
     """
     Make and return a string representing a (synthetic) term in a randomly-
@@ -92,7 +104,8 @@ def make_term():
     """
     global _term_count
     language = random_gen.choice(LANGUAGES, p=LANGUAGE_PROBA)
-    term_text = 'term{}'.format(_term_count)
+    term_letters = _numbers_to_letters(_term_count)
+    term_text = 'term_{}'.format(term_letters)
     term = concept_uri(language, term_text)
     _term_count += 1
     return term


### PR DESCRIPTION
The 'propagate' step is useful: it provides almost all of the value of our OOV step of looking up neighbors in ConceptNet. If we propagate through the vocabulary properly, we no longer need to use the ConceptNet graph to get a satisfactory OOV strategy.

So that's what we're doing here, with just a minor fix to propagating through the vocabulary properly. It was using terms normalized as they are in ConceptNet, when it should be using the extra normalization of Numberbatch (which calls `replace_numbers` to replace sequences of digits).

This will go into the release called 19.07 or 19.08.