### PR TITLE
modify test db creation fixture to work with the --quick flag

### DIFF
--- a/conceptnet5/tests/conftest.py
+++ b/conceptnet5/tests/conftest.py
@@ -27,9 +27,10 @@ def test_env_variables():
     return env_variables
 
 @pytest.fixture(scope='session')
-def create_test_db():
-    subprocess.run(["dropdb", "conceptnet-test", "--if-exists"])
-    subprocess.run(["createdb", "conceptnet-test"])
+def create_test_db(is_quick_run):
+    if not is_quick_run:
+        subprocess.run(["dropdb", "conceptnet-test", "--if-exists"])
+        subprocess.run(["createdb", "conceptnet-test"])
 
 def run_snakemake(env_variables, options=('-j', '4'), targets=()):
     cmd_args = ["snakemake"] + list(options) + list(targets)


### PR DESCRIPTION
Makes the fix for creating the conceptnet-test db in a fixture work with the --quick flag by not refreshing the db when --quick is specified.