### PR TITLE
update the vector space export process, fixing Korean

### DIFF
--- a/conceptnet5/vectors/cli.py
+++ b/conceptnet5/vectors/cli.py
@@ -1,3 +1,4 @@
+import os
 from os import path
 
 import click
@@ -294,6 +295,7 @@ def run_miniaturize(input_filename, extra_vocab_filename, output_filename, k):
 @click.argument('concepts_filename', type=click.Path(readable=True, dir_okay=False))
 @click.option('-l', '--language', default='en')
 def export_background(input_filename, output_dir, concepts_filename, language):
+    os.makedirs(output_dir, exist_ok=True)
     concepts = set(line.strip() for line in open(concepts_filename))
     frame = load_hdf(input_filename)
     big_frame = make_big_frame(frame, language)

--- a/conceptnet5/vectors/transforms.py
+++ b/conceptnet5/vectors/transforms.py
@@ -105,9 +105,15 @@ def choose_small_vocabulary(index, concepts):
     """
     Choose the vocabulary of the small frame, by eliminating the terms which:
      - contain more than one word
-     - are not in ConceptNet
+     - are not in the 'core' set of ConceptNet
+
+    ...but keeping the terms in Korean, which would be too aggressively filtered
+    by those criteria.
     """
-    vocab = [term for term in index if '_' not in term and term in concepts]
+    vocab = [
+        term for term in index
+        if ('_' not in term and term in concepts) or term.startswith('/c/ko/')
+    ]
     return vocab
 
 


### PR DESCRIPTION
We found that filtering Korean for single words in the core set left too few terms in the language-specific vector space. In practice, we made an exception to leave Korean unfiltered. Now that exception is here in the code.