### PR TITLE
optimize postgresql queries and psycopg2 codes

### DIFF
--- a/conceptnet5/db/cli.py
+++ b/conceptnet5/db/cli.py
@@ -29,6 +29,7 @@ def load_data(input_dir):
     create_tables(conn)
     load_sql_csv(conn, input_dir)
     create_indices(conn)
+    conn.close()
 
 
 @cli.command(name='check')

--- a/conceptnet5/db/prepare_data.py
+++ b/conceptnet5/db/prepare_data.py
@@ -230,7 +230,8 @@ def load_sql_csv(connection, input_dir):
         (input_dir + '/edges_gin.shuf.csv', 'edges_gin'),
         (input_dir + '/edge_features.csv', 'edge_features'),
     ]:
-        with connection.cursor() as cursor:
-            with open(filename, 'rb') as file:
-                cursor.copy_from(file, tablename)
-        connection.commit()
+        with connection:
+            with connection.cursor() as cursor:
+                with open(filename, 'rb') as file:
+                    cursor.execute('TRUNCATE {}'.format(tablename))
+                    cursor.copy_from(file, tablename)


### PR DESCRIPTION

## postgresql queries
The current queries require substantial amount of time to create a database. I tried to build the conceptnet5 in my environment, but **the process stuck for 24+ hours** and I finally gave up building it. 

[PostgreSQL: Documentation: 12: 14.4. Populating a Database](https://www.postgresql.org/docs/12/populate.html) provides some tips for importing a large amount of data.

My edits are:
- conceptnet5/db/prepare_data.py: Add `TRUNCATE` before `COPY FROM` in the same transaction.
- conceptnet5/db/schema.py:
    - Remove indexes and foreign key constraints in `CREATE TABLE` queries
    - Add the equivalent queries in `INDICES`

With this code, **the build finished in 2 hours in my environment** (I also changed database settings: `wal_level` to minimal, `archive_mode` to off, and `max_wal_senders` to zero).

##  psycopg2 codes
- conceptnet5/db/cli.py: Better to close a connection to prevent locking.
- conceptnet5/db/prepare_data.py: Better to use a `with` context manager so that a transaction can be rolled back in case of an exception.

[The connection class — Psycopg 2.8.7.dev0 documentation](https://www.psycopg.org/docs/connection.html)

> Connections can be used as context managers. Note that a context wraps a transaction: if the context exits with success the transaction is committed, if it exits with an exception the transaction is rolled back. Note that the connection is not closed by the context and it can be used for several contexts.

I'm not sure why connection.commit() is included in the source code with conn.autocommit enabled.... This is another problem, though.


