### PR TITLE
Bug: AssertionFinder.connection missing `self` arg

### DIFF
--- a/conceptnet5/db/query.py
+++ b/conceptnet5/db/query.py
@@ -125,7 +125,7 @@ class AssertionFinder(object):
         self.dbname = dbname
 
     @property
-    def connection():
+    def connection(self):
         # See https://www.psycopg.org/docs/connection.html#connection.closed
         if self._connection is None or self._connection.closed > 0:
             self._connection = get_db_connection(self.dbname)


### PR DESCRIPTION
I found out the solution for this error:

```
Traceback (most recent call last):
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask/app.py", line 2091, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask/app.py", line 2076, in wsgi_app
    response = self.handle_exception(e)
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/lol/anaconda3/envs/conceptnet/lib/python3.8/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/lol/conceptnet5/web/conceptnet_web/api.py", line 69, in query_node
    results = responses.lookup_paginated(path, offset=offset, limit=limit)
  File "/home/lol/conceptnet5/conceptnet5/api.py", line 150, in lookup_paginated
    found = FINDER.lookup(term, limit=(limit + 1), offset=offset)
  File "/home/lol/conceptnet5/conceptnet5/db/query.py", line 150, in lookup
    return self.query(criteria, limit, offset)
  File "/home/lol/conceptnet5/conceptnet5/db/query.py", line 231, in query
    cursor = self.connection.cursor()
TypeError: connection() takes 0 positional arguments but 1 was given
```