### PR TITLE
Add ipadic as a pip dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     },
     extras_require={
         'vectors': ['numpy', 'scipy', 'statsmodels', 'tables', 'pandas', 'scikit-learn',
-                    'mecab-python3', 'jieba', 'marisa_trie', 'matplotlib >= 2', 'annoy']
+                    'mecab-python3', 'jieba', 'marisa_trie', 'matplotlib >= 2', 'annoy', 'ipadic']
     },
 )


### PR DESCRIPTION
The build process threw an error because I did not have ipadic installed via pip.